### PR TITLE
Chore/11 initialize project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+minishell
+*.o
+obj/
+*.d
+*.a
+compile_flags.txt
+compile_commands.json

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+# Compiler and flags
+
+CC = cc
+CFLAGS = -Wall -Wextra -Werror
+
+# Directories
+
+SRC_DIR = src/
+OBJ_DIR = obj/
+INCLUDE_DIR = include/
+LIBFT_DIR = libft/
+
+# Files
+
+SRCS = minishell.c
+OBJS = $(SRCS:%.c=$(OBJ_DIR)%.o)
+DEPS = $(OBJS:%.o=%.d)
+INCLUDES = -I$(INCLUDE_DIR) -I$(LIBFT_DIR)
+LIBFT = $(LIBFT_DIR)libft.a
+
+NAME = minishell
+
+all: $(NAME)
+
+libs:
+	$(MAKE) -C $(LIBFT_DIR)
+
+$(NAME): $(OBJS) | libs
+	$(CC) $(CFLAGS) $(OBJS) $(LIBFT) -o $(NAME)
+
+$(OBJ_DIR)%.o: $(SRC_DIR)%.c
+	mkdir -p $(OBJ_DIR)
+	$(CC) $(CFLAGS) $(INCLUDES) -MMD -MP -c $< -o $@
+
+clean:
+	rm -rf $(OBJ_DIR)
+	$(MAKE) -C $(LIBFT_DIR) clean
+
+fclean: clean
+	rm -rf $(NAME)
+	$(MAKE) -C $(LIBFT_DIR) fclean
+
+re: fclean all
+
+-include $(DEPS)
+
+.PHONY: all libs fclean clean re


### PR DESCRIPTION
This pull request introduces a `Makefile` to streamline the build process for the `minishell` project. The `Makefile` defines compilation rules, organizes source and object files, and integrates with the `libft` library.

### Build system setup:

* Added a `Makefile` to manage the build process, including compilation flags (`CFLAGS`), source and object directories, and dependencies.
* Defined rules for building the `minishell` executable, creating object files, and generating dependency files.
* Integrated the `libft` library by adding a `libs` target that builds it and linking it during the `minishell` build process.

### Cleanup and rebuild functionality:

* Added `clean` and `fclean` targets to remove object files, dependency files, and the `minishell` executable.
* Included a `re` target for rebuilding the project from scratch.

### Quality-of-life improvements:

* Added `.PHONY` targets to ensure proper execution of non-file targets like `clean`, `fclean`, and `re`.