### PR TITLE
feat: implement builtin unset

### DIFF
--- a/src/builtin/builtin_unset.c
+++ b/src/builtin/builtin_unset.c
@@ -6,16 +6,45 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/05 17:52:38 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/05/07 14:29:01 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/05/07 19:31:15 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtins.h"
 #include "parser.h"
+#include "libft.h"
+#include <stdlib.h>
 
 int	builtin_unset(t_cmd *cmd, t_env_list **env)
 {
-	(void)cmd;
-	(void)env;
+	t_env_list	*cur;
+	t_env_list	*prev;
+
+	if (cmd->args[1] == NULL)
+	{
+		ft_putendl_fd("unset: not enough arguments", 2);
+		return (1);
+	}
+	if (env == NULL || *env == NULL)
+		return (0);
+	cur = *env;
+	prev = NULL;
+	while (cur && ft_strcmp(cur->key, cmd->args[1]) != 0)
+	{
+
+		prev = cur;
+		cur = cur->next;
+	}
+	if (cur)
+	{
+		if (prev)
+			prev->next = cur->next;
+		else
+			*env = cur->next;
+		free(cur->key);
+		free(cur->value);
+		free(cur);
+		return (0);
+	}
 	return (0);
 }


### PR DESCRIPTION
This pull request introduces a significant update to the `builtin_unset` function in `src/builtin/builtin_unset.c`, implementing its core functionality to remove an environment variable from the environment list. Key changes include adding error handling, iterating through the environment list, and freeing memory for the removed variable.

### Implementation of `builtin_unset` functionality:

* Added logic to handle cases where no arguments are provided to the `unset` command, displaying an error message using `ft_putendl_fd`.
* Implemented traversal of the `env` linked list to locate and remove the specified environment variable (`cmd->args[1]`), updating pointers to maintain the list structure.
* Included memory cleanup for the removed environment variable by freeing its `key`, `value`, and the node itself.

### Additional changes:

* Included new headers (`libft.h` and `<stdlib.h>`) to support string comparison (`ft_strcmp`) and memory management functions (`free`).