### PR TITLE
feat: implement error handling and environment variable removal in bu…

### DIFF
--- a/src/builtin/builtin_unset.c
+++ b/src/builtin/builtin_unset.c
@@ -6,16 +6,45 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/05 17:52:38 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/05/07 14:29:01 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/05/07 19:31:15 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtins.h"
 #include "parser.h"
+#include "libft.h"
+#include <stdlib.h>
 
 int	builtin_unset(t_cmd *cmd, t_env_list **env)
 {
-	(void)cmd;
-	(void)env;
+	t_env_list	*cur;
+	t_env_list	*prev;
+
+	if (cmd->args[1] == NULL)
+	{
+		ft_putendl_fd("unset: not enough arguments", 2);
+		return (1);
+	}
+	if (env == NULL || *env == NULL)
+		return (0);
+	cur = *env;
+	prev = NULL;
+	while (cur && ft_strcmp(cur->key, cmd->args[1]) != 0)
+	{
+
+		prev = cur;
+		cur = cur->next;
+	}
+	if (cur)
+	{
+		if (prev)
+			prev->next = cur->next;
+		else
+			*env = cur->next;
+		free(cur->key);
+		free(cur->value);
+		free(cur);
+		return (0);
+	}
 	return (0);
 }


### PR DESCRIPTION
This pull request introduces a functional implementation of the `builtin_unset` command in the `src/builtin/builtin_unset.c` file. The changes include adding logic to handle the removal of environment variables, error handling for missing arguments, and necessary header file imports.

### Functional updates to `builtin_unset`:

* Implemented logic to search for and remove an environment variable from the linked list, including updating pointers and freeing memory for the removed node.
* Added error handling to display an error message when no arguments are provided to the `unset` command.

### Dependency updates:

* Included `libft.h` for utility functions and `<stdlib.h>` for memory management.