### PR TITLE
Fix/builtin_echo_n_arg

### DIFF
--- a/src/builtin/builtin_echo.c
+++ b/src/builtin/builtin_echo.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/29 18:02:24 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/05/14 17:30:03 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/05/14 17:40:41 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,6 +46,20 @@ static int	is_arg_n(const char *arg)
 	return (1);
 }
 
+static void	print_args(char **argv, t_env_list **env)
+{
+	while (*argv != NULL)
+	{
+		if ((*argv)[0] == '$')
+			print_env(*argv + 1, *env);
+		else
+			printf("%s", *argv);
+		if (*(argv + 1) != NULL)
+			printf(" ");
+		argv++;
+	}
+}
+
 int	builtin_echo(t_cmd *cmd, t_env_list **env)
 {
 	char	**argv;
@@ -64,16 +78,7 @@ int	builtin_echo(t_cmd *cmd, t_env_list **env)
 			printf("\n");
 		return (0);
 	}
-	while (*argv != NULL)
-	{
-		if ((*argv)[0] == '$')
-			print_env(*argv + 1, *env);
-		else
-			printf("%s", *argv);
-		if (*(argv + 1) != NULL)
-			printf(" ");
-		argv++;
-	}
+	print_args(argv, env);
 	if (has_n_arg == 0)
 		printf("\n");
 	return (0);

--- a/src/builtin/builtin_echo.c
+++ b/src/builtin/builtin_echo.c
@@ -6,14 +6,14 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/29 18:02:24 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/05/07 14:28:42 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/05/14 17:30:03 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtins.h"
 #include "libft.h"
-#include <stdio.h>
 #include "parser.h"
+#include <stdio.h>
 
 static void	print_env(char *var, t_env_list *env)
 {
@@ -33,6 +33,19 @@ static void	print_env(char *var, t_env_list *env)
 	}
 }
 
+static int	is_arg_n(const char *arg)
+{
+	if (arg[0] == '-')
+		arg++;
+	while (*arg)
+	{
+		if (*arg != 'n')
+			return (0);
+		arg++;
+	}
+	return (1);
+}
+
 int	builtin_echo(t_cmd *cmd, t_env_list **env)
 {
 	char	**argv;
@@ -40,7 +53,7 @@ int	builtin_echo(t_cmd *cmd, t_env_list **env)
 
 	argv = cmd->args + 1;
 	has_n_arg = 0;
-	while (*argv && (ft_strncmp(argv[0], "-n", 3) == 0))
+	while (*argv && is_arg_n(argv[0]) == 1)
 	{
 		has_n_arg = 1;
 		argv++;


### PR DESCRIPTION
This pull request refactors the `builtin_echo` function in `src/builtin/builtin_echo.c` to improve code readability and modularity. The changes include introducing helper functions for argument handling and replacing inline logic with these functions.

### Code refactoring:

* **Introduced `is_arg_n` helper function**: Added a new static function `is_arg_n` to encapsulate the logic for identifying `-n` arguments, improving readability and reusability.
* **Introduced `print_args` helper function**: Added a new static function `print_args` to handle the printing of arguments, including environment variable expansion, simplifying the main `builtin_echo` function.
* **Replaced inline logic with `print_args`**: Updated the `builtin_echo` function to call `print_args` instead of containing the argument printing logic directly, reducing code duplication.

### Minor adjustments:

* **Header file order update**: Adjusted the order of included headers for consistency (`stdio.h` moved after `parser.h`).