### PR TITLE
39 sync env lists for execution

### DIFF
--- a/include/builtins.h
+++ b/include/builtins.h
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/30 15:11:19 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/05/15 16:05:11 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/05/15 16:54:25 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,26 +15,26 @@
 
 //#include "env.h"
 
-typedef struct s_cmd	t_cmd;
-typedef struct s_env_list t_env_list;
+typedef struct s_cmd		t_cmd;
+typedef struct s_env_list	t_env_list;
 
 // Built-ins
-typedef int				(*t_builtin_func)(t_cmd *cmd, t_env_list **env);
+typedef int					(*t_builtin_func)(t_cmd *cmd, t_env_list **env);
 
 typedef struct s_builtins_array
 {
-	char				*builtin_name;
-	t_builtin_func		handler;
-}						t_builtins_array;
+	char					*builtin_name;
+	t_builtin_func			handler;
+}							t_builtins_array;
 
 // Builtin Functions
-int						builtin_echo(t_cmd *cmd, t_env_list **env);
-int						builtin_cd(t_cmd *cmd, t_env_list **env);
-int						builtin_pwd(t_cmd *cmd, t_env_list **env);
-int						builtin_env(t_cmd *cmd, t_env_list **env);
-int						builtin_export(t_cmd *cmd, t_env_list **env);
-int						builtin_unset(t_cmd *cmd, t_env_list **env);
-int						builtin_exit(t_cmd *cmd, t_env_list **env);
-int						run_builtin(t_cmd *cmd, t_env_list **env);
+int							builtin_echo(t_cmd *cmd, t_env_list **env);
+int							builtin_cd(t_cmd *cmd, t_env_list **env);
+int							builtin_pwd(t_cmd *cmd, t_env_list **env);
+int							builtin_env(t_cmd *cmd, t_env_list **env);
+int							builtin_export(t_cmd *cmd, t_env_list **env);
+int							builtin_unset(t_cmd *cmd, t_env_list **env);
+int							builtin_exit(t_cmd *cmd, t_env_list **env);
+int							run_builtin(t_cmd *cmd, t_env_list **env);
 
 #endif

--- a/include/env.h
+++ b/include/env.h
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/15 16:03:21 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/05/15 16:37:46 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/05/15 16:52:48 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,8 +26,8 @@ typedef struct s_env_list
 
 t_env_list				*lst_init(char *const *envp);
 void					lst_clear(t_env_list **list);
-t_env_list	*lst_create_node(char *key, char *value);
-void	lst_add_end(t_env_list **list, t_env_list *new_node);
-size_t	lst_size(t_env_list **list);
+t_env_list				*lst_create_node(char *key, char *value);
+void					lst_add_end(t_env_list **list, t_env_list *new_node);
+size_t					lst_size(t_env_list **list);
 
 #endif

--- a/include/env.h
+++ b/include/env.h
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/15 16:03:21 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/05/15 16:52:48 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/05/15 16:57:37 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,5 +29,6 @@ void					lst_clear(t_env_list **list);
 t_env_list				*lst_create_node(char *key, char *value);
 void					lst_add_end(t_env_list **list, t_env_list *new_node);
 size_t					lst_size(t_env_list **list);
+char					**env_list_to_tab(t_env_list **env_list);
 
 #endif

--- a/src/env/env_list_to_tab.c
+++ b/src/env/env_list_to_tab.c
@@ -6,7 +6,38 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/15 16:00:25 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/05/15 16:02:53 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/05/15 16:27:37 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include "env.h"
+#include <stdlib.h>
+
+static char	*ft_strjoin3(char const *s1, char const *s2)
+{
+	size_t	total_len;
+	char	*res;
+
+	total_len = ft_strlen(s1) + ft_strlen(s2) + 1;
+	res = malloc(total_len + 1);
+	if (!res)
+		return (NULL);
+	res[0] = '\0';
+	ft_strlcat(res, s1, total_len + 1);
+    ft_strlcat(res, "=", 2);
+	ft_strlcat(res, s2, total_len + 1);
+	return (res);
+}
+
+char    **env_list_to_tab(t_env_list **env_list)
+{
+    char        **env_tab;
+    t_env_list  *tmp;
+
+    while (tmp)
+    {
+        
+        tmp = tmp->next;
+    }
+    return (env_tab);
+}

--- a/src/env/env_list_to_tab.c
+++ b/src/env/env_list_to_tab.c
@@ -6,12 +6,14 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/15 16:00:25 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/05/15 16:27:37 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/05/15 16:53:39 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "env.h"
+#include "libft.h"
 #include <stdlib.h>
+#include <stdio.h>
 
 static char	*ft_strjoin3(char const *s1, char const *s2)
 {
@@ -32,12 +34,24 @@ static char	*ft_strjoin3(char const *s1, char const *s2)
 char    **env_list_to_tab(t_env_list **env_list)
 {
     char        **env_tab;
+    size_t      size_of_list;
     t_env_list  *tmp;
 
+    tmp = *env_list;
+    if ((size_of_list = lst_size(env_list)) == 0)
+        return (NULL);
+    env_tab = malloc(sizeof(char *) * size_of_list + 1);
+    if (env_tab == NULL)
+    {
+        perror("minishell:");
+        return (NULL);
+    }
+    env_tab[size_of_list + 1] = NULL; 
     while (tmp)
     {
-        
+        *env_tab = ft_strjoin3(tmp->key, tmp->value); 
         tmp = tmp->next;
+        (*env_tab)++;
     }
     return (env_tab);
 }

--- a/src/env/env_list_to_tab.c
+++ b/src/env/env_list_to_tab.c
@@ -6,14 +6,14 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/15 16:00:25 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/05/15 16:53:39 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/05/15 17:23:10 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "env.h"
 #include "libft.h"
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 static char	*ft_strjoin3(char const *s1, char const *s2)
 {
@@ -26,32 +26,34 @@ static char	*ft_strjoin3(char const *s1, char const *s2)
 		return (NULL);
 	res[0] = '\0';
 	ft_strlcat(res, s1, total_len + 1);
-    ft_strlcat(res, "=", 2);
+	ft_strlcat(res, "=", total_len + 1);
 	ft_strlcat(res, s2, total_len + 1);
 	return (res);
 }
 
-char    **env_list_to_tab(t_env_list **env_list)
+char	**env_list_to_tab(t_env_list **env_list)
 {
-    char        **env_tab;
-    size_t      size_of_list;
-    t_env_list  *tmp;
+	char **env_tab;
+	size_t size_of_list;
+	t_env_list *tmp;
+	size_t i;
 
-    tmp = *env_list;
-    if ((size_of_list = lst_size(env_list)) == 0)
-        return (NULL);
-    env_tab = malloc(sizeof(char *) * size_of_list + 1);
-    if (env_tab == NULL)
-    {
-        perror("minishell:");
-        return (NULL);
-    }
-    env_tab[size_of_list + 1] = NULL; 
-    while (tmp)
-    {
-        *env_tab = ft_strjoin3(tmp->key, tmp->value); 
-        tmp = tmp->next;
-        (*env_tab)++;
-    }
-    return (env_tab);
+	tmp = *env_list;
+	if ((size_of_list = lst_size(env_list)) == 0)
+		return (NULL);
+	env_tab = malloc(sizeof(char *) * size_of_list + 1);
+	if (env_tab == NULL)
+	{
+		perror("minishell:");
+		return (NULL);
+	}
+	i = 0;
+	env_tab[size_of_list + 1] = NULL;
+	while (tmp && i < size_of_list)
+	{
+		env_tab[i] = ft_strjoin3(tmp->key, tmp->value);
+		tmp = tmp->next;
+		i++;
+	}
+	return (env_tab);
 }

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/27 14:08:36 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/05/15 16:10:09 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/05/15 17:29:14 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,6 +19,7 @@
 int	main(int argc, char **argv, char **envp)
 {
 	t_env_list	*env_list;
+	char		**env_tab;
 
 	(void)argc;
 	(void)argv;
@@ -28,8 +29,9 @@ int	main(int argc, char **argv, char **envp)
 		perror("minishell: init env");
 		return (1);
 	}
-	//TODO Pass only env_list in readline loop
-	readline_loop(envp, &env_list);
+	env_tab = env_list_to_tab(&env_list);
+	// TODO Pass only env_list in readline loop
+	readline_loop(env_tab, &env_list);
 	lst_clear(&env_list);
 	return (0);
 }


### PR DESCRIPTION
This pull request introduces a new feature to convert an environment variable linked list into a string array (`env_list_to_tab`) and integrates it into the `minishell` application. The changes include adding a utility function, updating the environment list header, and modifying the main program logic to use the new functionality.

### New Feature: Environment List to String Array Conversion

* **`include/env.h`**: Added the prototype for the new function `env_list_to_tab`, which converts a linked list of environment variables into a string array.
* **`src/env/env_list_to_tab.c`**: Implemented the `env_list_to_tab` function. This includes a helper function `ft_strjoin3` to concatenate key-value pairs with an `=` separator, and the main logic to iterate through the linked list and populate the string array.

### Integration into `minishell`

* **`src/minishell.c`**: Updated the `main` function to call `env_list_to_tab` and pass the resulting string array (`env_tab`) to the `readline_loop` function instead of the original `envp`. This ensures the program operates on the updated environment list. [[1]](diffhunk://#diff-24d116499e6a7c6e447029d7af7c182d0e1663db9df63cf5ca065d3ef1426933R22) [[2]](diffhunk://#diff-24d116499e6a7c6e447029d7af7c182d0e1663db9df63cf5ca065d3ef1426933R32-R34)