### PR TITLE
39 sync env lists for execution

### DIFF
--- a/src/env/env_list_to_tab.c
+++ b/src/env/env_list_to_tab.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   env_list_to_tab.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
+/*   By: denissemenov <denissemenov@student.42.f    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/15 16:00:25 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/05/15 17:23:10 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/05/16 00:29:52 by denissemeno      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,6 +20,8 @@ static char	*ft_strjoin3(char const *s1, char const *s2)
 	size_t	total_len;
 	char	*res;
 
+	if (s1 == NULL || s2 == NULL)
+		return (NULL);
 	total_len = ft_strlen(s1) + ft_strlen(s2) + 1;
 	res = malloc(total_len + 1);
 	if (!res)
@@ -31,29 +33,70 @@ static char	*ft_strjoin3(char const *s1, char const *s2)
 	return (res);
 }
 
-char	**env_list_to_tab(t_env_list **env_list)
+static void free_env_tab(char **env_tab)
 {
-	char **env_tab;
-	size_t size_of_list;
-	t_env_list *tmp;
-	size_t i;
+	char **tmp;
 
-	tmp = *env_list;
-	if ((size_of_list = lst_size(env_list)) == 0)
-		return (NULL);
-	env_tab = malloc(sizeof(char *) * (size_of_list + 1));
 	if (env_tab == NULL)
+		return ;
+	tmp = env_tab;
+	while (*tmp)
+	{
+		free(*tmp);
+		tmp++;
+	}
+	free(env_tab);
+}
+
+static char **return_empty_tab(void)
+{
+	char **tab;
+
+	tab = malloc(sizeof(char *));
+	if (tab == NULL)
 	{
 		perror("minishell:");
 		return (NULL);
 	}
+	*tab = NULL;
+	return (tab);
+}
+static char **fill_tab(t_env_list **list, char **tab, size_t len)
+{
+	t_env_list *tmp;
+	size_t i;
+
+	tmp = *list;
 	i = 0;
-	env_tab[size_of_list] = NULL;
-	while (tmp && i < size_of_list)
+	while (tmp && i < len)
 	{
-		env_tab[i] = ft_strjoin3(tmp->key, tmp->value);
+		tab[i] = ft_strjoin3(tmp->key, tmp->value);
+		if (tab[i] == NULL)
+		{
+			free_env_tab(tab);
+			perror("minishell");
+			return (NULL);
+		}
 		tmp = tmp->next;
 		i++;
 	}
+	return (tab);
+}
+
+char	**env_list_to_tab(t_env_list **env_list)
+{
+	char **env_tab;
+	size_t len;
+
+	if ((!env_list) || ((len = lst_size(env_list)) == 0))
+		return(return_empty_tab());
+	env_tab = malloc(sizeof(char *) * (len + 1));
+	if (env_tab == NULL)
+	{
+		perror("minishell");
+		return (NULL);
+	}
+	env_tab[len] = NULL;
+	env_tab = fill_tab(env_list, env_tab, len);
 	return (env_tab);
 }

--- a/src/env/env_list_to_tab.c
+++ b/src/env/env_list_to_tab.c
@@ -41,14 +41,14 @@ char	**env_list_to_tab(t_env_list **env_list)
 	tmp = *env_list;
 	if ((size_of_list = lst_size(env_list)) == 0)
 		return (NULL);
-	env_tab = malloc(sizeof(char *) * size_of_list + 1);
+	env_tab = malloc(sizeof(char *) * (size_of_list + 1));
 	if (env_tab == NULL)
 	{
 		perror("minishell:");
 		return (NULL);
 	}
 	i = 0;
-	env_tab[size_of_list + 1] = NULL;
+	env_tab[size_of_list] = NULL;
 	while (tmp && i < size_of_list)
 	{
 		env_tab[i] = ft_strjoin3(tmp->key, tmp->value);


### PR DESCRIPTION
This pull request refactors and improves the `env_list_to_tab.c` file by introducing better memory management, error handling, and modularity in the code. The most important changes include adding null checks, modularizing the code into smaller helper functions, and improving memory cleanup to prevent potential leaks.

### Improvements to memory management and error handling:

* Added null checks in the `ft_strjoin3` function to handle cases where input strings might be `NULL`. This prevents undefined behavior when concatenating strings. (`[src/env/env_list_to_tab.cR23-R24](diffhunk://#diff-f56fee0965d8eee1dc545d113f8c8391952395b68e4d4d92befe323ce3a67da7R23-R24)`)
* Introduced the `free_env_tab` function to properly free memory allocated for the environment variable table, preventing potential memory leaks. (`[src/env/env_list_to_tab.cL34-R100](diffhunk://#diff-f56fee0965d8eee1dc545d113f8c8391952395b68e4d4d92befe323ce3a67da7L34-R100)`)

### Code modularization:

* Added the `return_empty_tab` helper function to handle cases where the environment list is empty, ensuring a consistent return value of an empty table. (`[src/env/env_list_to_tab.cL34-R100](diffhunk://#diff-f56fee0965d8eee1dc545d113f8c8391952395b68e4d4d92befe323ce3a67da7L34-R100)`)
* Created the `fill_tab` helper function to encapsulate the logic for populating the environment variable table, improving readability and separation of concerns. (`[src/env/env_list_to_tab.cL34-R100](diffhunk://#diff-f56fee0965d8eee1dc545d113f8c8391952395b68e4d4d92befe323ce3a67da7L34-R100)`)

### General updates:

* Updated the author metadata in the file header to reflect the correct author name and timestamp. (`[src/env/env_list_to_tab.cL6-R9](diffhunk://#diff-f56fee0965d8eee1dc545d113f8c8391952395b68e4d4d92befe323ce3a67da7L6-R9)`)