### PR TITLE
refactor: env_tab is updated each time when any command is executed

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/27 14:09:40 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/05/07 17:20:04 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/05/16 14:45:26 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,8 +45,7 @@ void						print_tokens(t_token *tokens);
 void						free_tokens(t_token *tokens);
 
 // readline_loop.c
-typedef struct s_env_list 	t_env_list;
-void						readline_loop(char **envp, 
-								t_env_list **env_variables);
+typedef struct s_env_list	t_env_list;
+void						readline_loop(t_env_list **env_variables);
 
 #endif

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/27 14:08:36 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/05/15 17:29:14 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/05/16 14:45:34 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@
 int	main(int argc, char **argv, char **envp)
 {
 	t_env_list	*env_list;
-	char		**env_tab;
+	// char		**env_tab;
 
 	(void)argc;
 	(void)argv;
@@ -29,9 +29,9 @@ int	main(int argc, char **argv, char **envp)
 		perror("minishell: init env");
 		return (1);
 	}
-	env_tab = env_list_to_tab(&env_list);
+	// env_tab = env_list_to_tab(&env_list);
 	// TODO Pass only env_list in readline loop
-	readline_loop(env_tab, &env_list);
+	readline_loop(&env_list);
 	lst_clear(&env_list);
 	return (0);
 }

--- a/src/readline_loop.c
+++ b/src/readline_loop.c
@@ -6,11 +6,12 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/28 19:02:03 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/05/13 18:59:00 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/05/16 15:28:55 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtins.h"
+#include "env.h"
 #include "executor.h"
 #include "libft.h"
 #include "minishell.h"
@@ -21,11 +22,13 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-void	executor(t_cmd *cmd, char **envp, t_env_list **env_variables)
+void	executor(t_cmd *cmd, t_env_list **env_variables)
 {
-	int	saved_stdin;
-	int	saved_stdout;
+	int		saved_stdin;
+	int		saved_stdout;
+	char	**envp;
 
+	envp = env_list_to_tab(env_variables);
 	if (cmd->next == NULL)
 	{
 		// Single command with possible redirection
@@ -47,7 +50,7 @@ void	executor(t_cmd *cmd, char **envp, t_env_list **env_variables)
 	free_cmd_list(cmd);
 }
 
-void	readline_loop(char **envp, t_env_list **env_variables)
+void	readline_loop(t_env_list **env_variables)
 {
 	t_token	*tokens;
 	t_cmd	*cmd;
@@ -74,7 +77,7 @@ void	readline_loop(char **envp, t_env_list **env_variables)
 				// print_cmds(cmd);
 			}
 			if (cmd)
-				executor(cmd, envp, env_variables);
+				executor(cmd, env_variables);
 			free_tokens(tokens);
 		}
 		free(input);


### PR DESCRIPTION
This pull request simplifies the management of environment variables in the `minishell` project by refactoring how they are passed between functions. The key changes include removing the `envp` parameter from several functions and instead dynamically generating it when needed, as well as updating function signatures and calls accordingly.

### Refactoring of environment variable management:

* [`include/minishell.h`](diffhunk://#diff-471850465338484d65e05947dade7a795e3e068ed9502a098e77c91b5ac1582fL49-R49): Updated the signature of `readline_loop` to remove the `envp` parameter, reflecting the new approach of passing only `t_env_list` for environment variable management.
* [`src/minishell.c`](diffhunk://#diff-24d116499e6a7c6e447029d7af7c182d0e1663db9df63cf5ca065d3ef1426933L22-R22): Commented out the `env_tab` variable and its associated logic in the `main` function. Updated the call to `readline_loop` to pass only `env_list`. [[1]](diffhunk://#diff-24d116499e6a7c6e447029d7af7c182d0e1663db9df63cf5ca065d3ef1426933L22-R22) [[2]](diffhunk://#diff-24d116499e6a7c6e447029d7af7c182d0e1663db9df63cf5ca065d3ef1426933L32-R34)
* [`src/readline_loop.c`](diffhunk://#diff-3c638e877f20879eafb4f7f8d7f548b03ff36391d3b5498288898bd67ac6ace6L24-R31): Updated the `executor` function to dynamically generate `envp` from `t_env_list` using `env_list_to_tab`. Modified the `readline_loop` function to remove the `envp` parameter and adjusted its calls to `executor` accordingly. [[1]](diffhunk://#diff-3c638e877f20879eafb4f7f8d7f548b03ff36391d3b5498288898bd67ac6ace6L24-R31) [[2]](diffhunk://#diff-3c638e877f20879eafb4f7f8d7f548b03ff36391d3b5498288898bd67ac6ace6L50-R53) [[3]](diffhunk://#diff-3c638e877f20879eafb4f7f8d7f548b03ff36391d3b5498288898bd67ac6ace6L77-R80)

### Miscellaneous updates:

* Updated file headers in `include/minishell.h`, `src/minishell.c`, and `src/readline_loop.c` to reflect the latest modification dates. [[1]](diffhunk://#diff-471850465338484d65e05947dade7a795e3e068ed9502a098e77c91b5ac1582fL9-R9) [[2]](diffhunk://#diff-24d116499e6a7c6e447029d7af7c182d0e1663db9df63cf5ca065d3ef1426933L9-R9) [[3]](diffhunk://#diff-3c638e877f20879eafb4f7f8d7f548b03ff36391d3b5498288898bd67ac6ace6L9-R14)
* Added a missing `#include "env.h"` directive in `src/readline_loop.c` to ensure access to environment-related utilities.