### PR TITLE
Signal handle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ LIBFT_DIR = libft/
 SRCS = minishell.c \
     	readline_loop.c \
 		exit_utils.c \
+		signals.c \
 		parser/redir_utils.c \
 		parser/lexer.c \
 		parser/lexer_utils.c \

--- a/include/executor.h
+++ b/include/executor.h
@@ -6,7 +6,7 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/06 12:39:30 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/05/23 18:07:40 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/05/23 22:09:37 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,5 +50,8 @@ int						handle_redirections(t_cmd *cmd);
 
 // exit_utils.c
 void					error_exit(char *msg);
+
+//signals.c
+void					setup_signal_handlers(void);
 
 #endif

--- a/src/executor/executor_utils.c
+++ b/src/executor/executor_utils.c
@@ -6,7 +6,7 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/12 10:19:46 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/05/23 20:20:33 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/05/23 22:56:23 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,7 @@
 #include "executor.h"
 #include "libft.h"
 #include <fcntl.h>
+#include <signal.h>
 #include <readline/readline.h>
 #include <stdlib.h>
 #include <sys/types.h>
@@ -170,6 +171,9 @@ void	fork_and_execute_cmd(t_cmd *cmd, t_shell *sh, int prev_fd, t_pipe pd)
 	// TODO: Change error exit (avoid exit call)
 	if (pid == 0)
 	{
+		// In the child process — default signal handling
+		signal(SIGINT, SIG_DFL);
+		signal(SIGQUIT, SIG_DFL);
 		setup_child_fds(prev_fd, pd, cmd);
 		execute_child(cmd, sh);
 		exit(0);

--- a/src/readline_loop.c
+++ b/src/readline_loop.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   readline_loop.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
+/*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/28 19:02:03 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/05/18 18:28:50 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/05/23 22:37:25 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,6 +24,7 @@ void	readline_loop(t_shell *sh)
 	t_cmd	*cmd;
 	char	*input;
 
+	setup_signal_handlers();
 	while ((input = readline("minishell > ")) != NULL)
 	{
 		if (input[0] != '\0')
@@ -47,4 +48,6 @@ void	readline_loop(t_shell *sh)
 		}
 		free(input);
 	}
+	// imitate Ctrl-D
+	write(1, "exit\n", 5);
 }

--- a/src/signals.c
+++ b/src/signals.c
@@ -6,7 +6,7 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/23 21:58:12 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/05/23 22:57:02 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/05/23 22:58:28 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,10 +19,10 @@
 static void	sigint_handler(int signo)
 {
 	(void)signo;
-	write(1, "\n", 1);    // new line
-	rl_on_new_line();       // notify readline that the screen is "rewound"
-	rl_replace_line("", 0); // clear the current input line
-	rl_redisplay();         // redraw the prompt
+	write(1, "\n", 1);
+	rl_on_new_line();
+	rl_replace_line("", 0);
+	rl_redisplay();
 }
 
 void	setup_signal_handlers(void)

--- a/src/signals.c
+++ b/src/signals.c
@@ -1,0 +1,36 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   signals.c                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/05/23 21:58:12 by tsargsya          #+#    #+#             */
+/*   Updated: 2025/05/23 22:57:02 by tsargsya         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <readline/history.h>
+#include <readline/readline.h>
+#include <signal.h>
+#include <unistd.h>
+
+// Handler for SIGINT (Ctrl-C)
+static void	sigint_handler(int signo)
+{
+	(void)signo;
+	write(1, "\n", 1);    // new line
+	rl_on_new_line();       // notify readline that the screen is "rewound"
+	rl_replace_line("", 0); // clear the current input line
+	rl_redisplay();         // redraw the prompt
+}
+
+void	setup_signal_handlers(void)
+{
+	// Disable readline's default signal handling
+	rl_catch_signals = 0;
+	// Ctrl-C → our handler
+	signal(SIGINT, sigint_handler);
+	// Ctrl-\ → ignore
+	signal(SIGQUIT, SIG_IGN);
+}


### PR DESCRIPTION
This pull request introduces signal handling improvements to the `minishell` project by adding a new `signals.c` file, updating the signal behavior in the `readline_loop` and child processes, and modifying related headers and source files. These changes enhance the user experience by handling signals like `Ctrl-C` and `Ctrl- more gracefully and ensuring proper cleanup on exit.

### Signal handling improvements:

* **New `signals.c` file:** Added `signals.c` to define a custom `SIGINT` handler for `Ctrl-C` and to ignore `SIGQUIT`. The `setup_signal_handlers` function configures these handlers and disables readline's default signal handling. (`src/signals.c`)

* **Integration of signal handlers:**
  - Updated `readline_loop` to call `setup_signal_handlers` at the start, ensuring custom signal handling is active during the shell's main loop. (`src/readline_loop.c`)
  - Added a graceful exit message ("exit\n") to mimic `Ctrl-D` behavior when the shell terminates. (`src/readline_loop.c`)

* **Child process signal handling:** Modified the `fork_and_execute_cmd` function to reset signal handlers to their default behavior (`SIG_DFL`) in child processes to ensure proper signal handling during command execution. (`src/executor/executor_utils.c`)

### Header and dependency updates:

* **Header updates:** Declared `setup_signal_handlers` in `executor.h` to make it accessible across the project. (`include/executor.h`)
* **Dependency updates:** Added `signal.h` to `executor_utils.c` to support signal-related functionality. (`src/executor/executor_utils.c`)

### Miscellaneous:

* **Makefile update:** Included `signals.c` in the list of source files to ensure it is compiled. (`Makefile`)