### PR TITLE
Handling quotes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ SRCS = minishell.c \
 		parser/lexer.c \
 		parser/lexer_utils.c \
 		parser/parser.c \
+		parser/expand_vars.c \
 		builtin/run_builtin.c \
 		builtin/builtin_echo.c \
 		builtin/builtin_cd.c \

--- a/README.md
+++ b/README.md
@@ -137,25 +137,25 @@ This project is about creating a simple shell. Yes, your own little bash. You wi
 
 | #  | Command                          | Expected Output / Behavior                                    | Checked |
 |:--:|:---------------------------------|:--------------------------------------------------------------|:--------|
-| 1  | `echo $HOME`                     | `<HOME-value>\n`, <br> exit code `0`                          |         |
-| 2  | `echo "$HOME"`                   | `<HOME-value>\n`, <br> exit code `0`                          |         |
-| 3  | `echo '$HOME'`                   | `$HOME\n`, <br> exit code `0`                                 |         |
-| 4  | `echo pre"$HOME"post`            | `pre<HOME-value>post\n`, <br> exit code `0`                   |         |
-| 5  | `echo pre'$HOME'post`            | `pre$HOMEpost\n`, <br> exit code `0`                          |         |
-| 6  | `echo "$USER:$HOME"`             | `<USER-value>:<HOME-value>\n`, <br> exit code `0`             |         |
-| 7  | `echo $UNSET_VAR`                | `\n` (empty), <br> exit code `0`                              |         |
-| 8  | `echo "$UNSET_VAR"`              | `\n` (empty), <br> exit code `0`                              |         |
-| 9  | `echo $?`                        | `<last_status>\n`, <br> exit code `0`                         |         |
-| 10 | `echo "Status=$?"`               | `Status=<last_status>\n`, <br> exit code `0`                  |         |
-| 11 | `echo "Cost is \$5"`             | `Cost is $5\n`, <br> exit code `0`                            |         |
-| 12 | `echo ${HOME}`                   | `${HOME}\n`, <br> exit code `0`                               |         |
-| 13 | `echo $-foo`                     | `-foo\n`, <br> exit code `0`                                  |         |
-| 14 | `echo a$HOMEb${UNSET}_$?`        | `a<HOME-value>b_<last_status>\n`, <br> exit code `0`          |         |
-| 15 | `echo "Path is $USER/bin:$HOME"` | `Path is <USER-value>/bin:<HOME-value>\n`, <br> exit code `0` |         |
-| 16 | `ls $HOME`                       | Directory listing of `$HOME`, <br> exit code `0`              |         |
-| 17 | `ls "$HOME"`                     | Directory listing of `$HOME`, <br> exit code `0`              |         |
-| 18 | `ls '$HOME'`                     | `ls: cannot access '$HOME': No such file or directory\n`, <br> exit code `2` |         |
-| 19 | `touch $PWD/testfile`            | no stdout, <br> creates file `$PWD/testfile`, exit code `0`   |         |
-| 20 | `rm $HOME/testfile`              | no stdout, <br> removes file `$HOME/testfile`, exit code `0`  |         |
-| 21 | `touch "$PWD"/testfile`          | no stdout, <br> creates file `$PWD/testfile`, exit code `0`   |         |
-| 22 | `rm "$HOME"/testfile`            | no stdout, <br> removes file `$HOME/testfile`, exit code `0`  |         |
+| 1  | `echo $HOME`                     | `<HOME-value>\n`, <br> exit code `0`                          | ✅ |
+| 2  | `echo "$HOME"`                   | `<HOME-value>\n`, <br> exit code `0`                          | ✅ |
+| 3  | `echo '$HOME'`                   | `$HOME\n`, <br> exit code `0`                                 | ❌ |
+| 4  | `echo pre"$HOME"post`            | `pre<HOME-value>post\n`, <br> exit code `0`                   | ❌ |
+| 5  | `echo pre'$HOME'post`            | `pre$HOMEpost\n`, <br> exit code `0`                          | ❌ |
+| 6  | `echo "$USER:$HOME"`             | `<USER-value>:<HOME-value>\n`, <br> exit code `0`             | ✅ |
+| 7  | `echo $UNSET_VAR`                | `\n` (empty), <br> exit code `0`                              | ✅ |
+| 8  | `echo "$UNSET_VAR"`              | `\n` (empty), <br> exit code `0`                              | ✅ |
+| 9  | `echo $?`                        | `<last_status>\n`, <br> exit code `0`                         | ✅ |
+| 10 | `echo "Status=$?"`               | `Status=<last_status>\n`, <br> exit code `0`                  | ✅ |
+| 11 | `echo "Cost is 5$"`              | `Cost is 5$\n`, <br> exit code `0`                            | ✅ |
+| 12 | `echo ${HOME}`                   | `${HOME}\n`, <br> exit code `0`                               | ❌ |
+| 13 | `echo $-foo`                     | `-foo\n`, <br> exit code `0`                                  | ❌ |
+| 14 | `echo a$HOMEb${UNSET}_$?`        | `a<HOME-value>b_<last_status>\n`, <br> exit code `0`          | ❌ |
+| 15 | `echo "Path is $USER/bin:$HOME"` | `Path is <USER-value>/bin:<HOME-value>\n`, <br> exit code `0` | ✅ |
+| 16 | `ls $HOME`                       | Directory listing of `$HOME`, <br> exit code `0`              | ✅ |
+| 17 | `ls "$HOME"`                     | Directory listing of `$HOME`, <br> exit code `0`              | ✅ |
+| 18 | `ls '$HOME'`                     | `ls: cannot access '$HOME': No such file or directory\n`, <br> exit code `2` | ✅ |
+| 19 | `touch $PWD/testfile`            | no stdout, <br> creates file `$PWD/testfile`, exit code `0`   | ✅ |
+| 20 | `rm $PWD/testfile`               | no stdout, <br> removes file `$HOME/testfile`, exit code `0`  | ✅ |
+| 21 | `touch "$PWD"/testfile`          | no stdout, <br> creates file `$PWD/testfile`, exit code `0`   | ❌ |
+| 22 | `rm "$PWD"/testfile`             | no stdout, <br> removes file `$HOME/testfile`, exit code `0`  | ❌ |

--- a/README.md
+++ b/README.md
@@ -123,3 +123,4 @@ This project is about creating a simple shell. Yes, your own little bash. You wi
 | 13 | `cat < out1 < out2 \| grep o > out3 > out4` | reads from `out2`<br>`[out3]`: exists and is empty<br>`[out4]`: contains lines with 'o' from `out2`<br>stdout empty<br>exit code: `0` | ✅ |
 
 echo "Path is $HOME/bin:$PATH"
+echo "Path is $HOME/bin:$HOME"

--- a/README.md
+++ b/README.md
@@ -121,3 +121,5 @@ This project is about creating a simple shell. Yes, your own little bash. You wi
 | 11 | `echo hi > out1.txt < in.txt` | `[out1.txt]`: `hi\n`<br>stdout empty<br>exit code: `0` | ✅ |
 | 12 | `cat << EOF > out.txt` <br>`foo`<br>`bar`<br>`EOF` | `[out.txt]`: `foo\n bar\n` <br>stdout empty<br>exit code: `0` | ✅ |
 | 13 | `cat < out1 < out2 \| grep o > out3 > out4` | reads from `out2`<br>`[out3]`: exists and is empty<br>`[out4]`: contains lines with 'o' from `out2`<br>stdout empty<br>exit code: `0` | ✅ |
+
+echo "Path is $HOME/bin:$PATH"

--- a/README.md
+++ b/README.md
@@ -122,5 +122,40 @@ This project is about creating a simple shell. Yes, your own little bash. You wi
 | 12 | `cat << EOF > out.txt` <br>`foo`<br>`bar`<br>`EOF` | `[out.txt]`: `foo\n bar\n` <br>stdout empty<br>exit code: `0` | ✅ |
 | 13 | `cat < out1 < out2 \| grep o > out3 > out4` | reads from `out2`<br>`[out3]`: exists and is empty<br>`[out4]`: contains lines with 'o' from `out2`<br>stdout empty<br>exit code: `0` | ✅ |
 
-echo "Path is $HOME/bin:$PATH"
-echo "Path is $HOME/bin:$HOME"
+---
+# Minishell - Quotes & Expansions Test Cases
+
+## ⚙️ Quotes & Expansion Behavior Legend
+- Output content (e.g. stdout, showing `\n` as newline)  
+- Exit status (retrieved by running `echo $?`)  
+- Single quotes: literal, no variable expansion  
+- Double quotes: allow variable expansion  
+- Unquoted: allow variable expansion  
+- Escaped or invalid `$`: treated as literal  
+
+---
+
+| #  | Command                          | Expected Output / Behavior                                    | Checked |
+|:--:|:---------------------------------|:--------------------------------------------------------------|:--------|
+| 1  | `echo $HOME`                     | `<HOME-value>\n`, <br> exit code `0`                          |         |
+| 2  | `echo "$HOME"`                   | `<HOME-value>\n`, <br> exit code `0`                          |         |
+| 3  | `echo '$HOME'`                   | `$HOME\n`, <br> exit code `0`                                 |         |
+| 4  | `echo pre"$HOME"post`            | `pre<HOME-value>post\n`, <br> exit code `0`                   |         |
+| 5  | `echo pre'$HOME'post`            | `pre$HOMEpost\n`, <br> exit code `0`                          |         |
+| 6  | `echo "$USER:$HOME"`             | `<USER-value>:<HOME-value>\n`, <br> exit code `0`             |         |
+| 7  | `echo $UNSET_VAR`                | `\n` (empty), <br> exit code `0`                              |         |
+| 8  | `echo "$UNSET_VAR"`              | `\n` (empty), <br> exit code `0`                              |         |
+| 9  | `echo $?`                        | `<last_status>\n`, <br> exit code `0`                         |         |
+| 10 | `echo "Status=$?"`               | `Status=<last_status>\n`, <br> exit code `0`                  |         |
+| 11 | `echo "Cost is \$5"`             | `Cost is $5\n`, <br> exit code `0`                            |         |
+| 12 | `echo ${HOME}`                   | `${HOME}\n`, <br> exit code `0`                               |         |
+| 13 | `echo $-foo`                     | `-foo\n`, <br> exit code `0`                                  |         |
+| 14 | `echo a$HOMEb${UNSET}_$?`        | `a<HOME-value>b_<last_status>\n`, <br> exit code `0`          |         |
+| 15 | `echo "Path is $USER/bin:$HOME"` | `Path is <USER-value>/bin:<HOME-value>\n`, <br> exit code `0` |         |
+| 16 | `ls $HOME`                       | Directory listing of `$HOME`, <br> exit code `0`              |         |
+| 17 | `ls "$HOME"`                     | Directory listing of `$HOME`, <br> exit code `0`              |         |
+| 18 | `ls '$HOME'`                     | `ls: cannot access '$HOME': No such file or directory\n`, <br> exit code `2` |         |
+| 19 | `touch $PWD/testfile`            | no stdout, <br> creates file `$PWD/testfile`, exit code `0`   |         |
+| 20 | `rm $HOME/testfile`              | no stdout, <br> removes file `$HOME/testfile`, exit code `0`  |         |
+| 21 | `touch "$PWD"/testfile`          | no stdout, <br> creates file `$PWD/testfile`, exit code `0`   |         |
+| 22 | `rm "$HOME"/testfile`            | no stdout, <br> removes file `$HOME/testfile`, exit code `0`  |         |

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/27 14:09:40 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/05/23 20:37:28 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/05/24 11:48:16 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,6 +26,8 @@ typedef struct s_shell
 typedef enum e_token_type
 {
 	TOK_WORD,
+	TOK_SQUOTED,
+	TOK_DQUOTED,
 	TOK_PIPE,
 	TOK_LESS,
 	TOK_GREATER,

--- a/include/parser.h
+++ b/include/parser.h
@@ -6,7 +6,7 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/30 14:53:04 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/05/23 10:50:24 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/05/26 13:46:11 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,11 +46,14 @@ typedef struct s_redir
 }							t_redir;
 
 // parser.c
-t_cmd						*parse_tokens(t_token *tokens);
+t_cmd						*parse_tokens(t_token *tokens, t_shell *sh);
 void						print_cmds(t_cmd *cmd);
 void						free_cmd_list(t_cmd *cmd);
 
 // redir_utils.c
 void						add_redirection(t_cmd *cmd, t_redir_type type,
 								const char *filename);
+
+// expand_vars.c
+char						*expand_vars(const char *input, t_shell *sh);
 #endif

--- a/include/parser.h
+++ b/include/parser.h
@@ -6,7 +6,7 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/30 14:53:04 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/05/26 13:46:11 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/05/26 20:20:06 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,12 @@
 # include "minishell.h"
 
 # define INITIAL_ARG_CAP 8
+
+# define RED "\x1B[31m"
+# define GREEN "\x1B[32m"
+# define YELLOW "\x1B[33m"
+# define BLUE "\x1B[34m"
+# define RESET "\x1B[0m"
 
 typedef struct s_cmd		t_cmd;
 typedef enum e_redir_type	t_redir_type;

--- a/src/parser/expand_vars.c
+++ b/src/parser/expand_vars.c
@@ -6,7 +6,7 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/26 13:42:50 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/05/26 20:08:09 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/05/26 20:24:02 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,7 +40,7 @@ static char	*get_env_value(const char *var_name, t_env_list *env_list)
 	return ("");
 }
 
-// 1) $?
+// $?
 static int	handle_exit_status(const char *input, size_t *pos, char **result,
 		t_shell *sh)
 {
@@ -60,7 +60,7 @@ static int	handle_exit_status(const char *input, size_t *pos, char **result,
 	return (SUCCESS);
 }
 
-// 2) $NAME
+// $NAME
 static int	handle_env_var(const char *input, size_t *pos, char **result,
 		t_shell *sh)
 {

--- a/src/parser/expand_vars.c
+++ b/src/parser/expand_vars.c
@@ -6,119 +6,120 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/26 13:42:50 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/05/26 20:04:18 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/05/26 20:08:09 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include "env.h"
+#include "executor.h"
 #include "libft.h"
 #include "minishell.h"
-#include "env.h"
 #include <stdlib.h>
-#include "executor.h"
 
-static int  handle_exit_status(const char *input, size_t *i, char **res, t_shell *sh);
-static int  handle_env_var(const char *input, size_t *i, char **res, t_shell *sh);
-static void append_char_to_result(const char *input, size_t *pos, char **result);
-static char *get_env_value(const char *var_name, t_env_list *env_list);
+static int	handle_exit_status(const char *input, size_t *i, char **res,
+				t_shell *sh);
+static int	handle_env_var(const char *input, size_t *i, char **res,
+				t_shell *sh);
+static void	append_char_to_result(const char *input, size_t *pos,
+				char **result);
+static char	*get_env_value(const char *var_name, t_env_list *env_list);
 
-static char *get_env_value(const char *var_name, t_env_list *env_list)
+static char	*get_env_value(const char *var_name, t_env_list *env_list)
 {
-    t_env_list *tmp = env_list;
-    size_t      len;
+	t_env_list	*tmp;
+	size_t		len;
 
-    while (tmp)
-    {
-        len = ft_strlen(tmp->key); 
-        if (ft_strncmp(tmp->key, var_name, len + 1) == 0)
-            return tmp->value;
-        tmp = tmp->next;
-    }
-    return ("");
+	tmp = env_list;
+	while (tmp)
+	{
+		len = ft_strlen(tmp->key);
+		if (ft_strncmp(tmp->key, var_name, len + 1) == 0)
+			return (tmp->value);
+		tmp = tmp->next;
+	}
+	return ("");
 }
 
 // 1) $?
-static int handle_exit_status(const char *input, size_t *pos, char **result, t_shell *sh)
+static int	handle_exit_status(const char *input, size_t *pos, char **result,
+		t_shell *sh)
 {
-    if (input[*pos + 1] != '?')
-        return (FAILURE);
+	char	*status_str;
+	char	*tmp;
 
-    char *status_str = ft_itoa(sh->last_status);
-    if (!status_str)
-        return (FAILURE);
-
-    char *tmp = *result;
-    *result = ft_strjoin(*result, status_str);
-    free(tmp);
-    free(status_str);
-
-    *pos += 2;
-    return (SUCCESS);
+	if (input[*pos + 1] != '?')
+		return (FAILURE);
+	status_str = ft_itoa(sh->last_status);
+	if (!status_str)
+		return (FAILURE);
+	tmp = *result;
+	*result = ft_strjoin(*result, status_str);
+	free(tmp);
+	free(status_str);
+	*pos += 2;
+	return (SUCCESS);
 }
 
 // 2) $NAME
-static int handle_env_var(const char *input, size_t *pos, char **result, t_shell *sh)
+static int	handle_env_var(const char *input, size_t *pos, char **result,
+		t_shell *sh)
 {
-    size_t j = *pos + 1;
-    if (!(ft_isalnum((unsigned char)input[j]) || input[j] == '_'))
-        return (FAILURE);
+	size_t	j;
+	char	*var_name;
+	char	*val;
+	char	*tmp;
 
-    while (input[j] && (ft_isalnum((unsigned char)input[j]) || input[j] == '_'))
-        j++;
-
-    char *var_name = ft_substr(input, *pos + 1, j - (*pos + 1));
-    if (!var_name)
-        return (FAILURE);
-
-    char *val = get_env_value(var_name, sh->env_list);
-    free(var_name);
-
-    char *tmp = *result;
-    *result = ft_strjoin(*result, val);
-    free(tmp);
-
-    *pos = j;
-    return (SUCCESS);
+	j = *pos + 1;
+	if (!(ft_isalnum((unsigned char)input[j]) || input[j] == '_'))
+		return (FAILURE);
+	while (input[j] && (ft_isalnum((unsigned char)input[j]) || input[j] == '_'))
+		j++;
+	var_name = ft_substr(input, *pos + 1, j - (*pos + 1));
+	if (!var_name)
+		return (FAILURE);
+	val = get_env_value(var_name, sh->env_list);
+	free(var_name);
+	tmp = *result;
+	*result = ft_strjoin(*result, val);
+	free(tmp);
+	*pos = j;
+	return (SUCCESS);
 }
 
-static void append_char_to_result(const char *input, size_t *pos, char **result)
+static void	append_char_to_result(const char *input, size_t *pos, char **result)
 {
-    char    buf[2];
-    char   *old;
+	char	buf[2];
+	char	*old;
 
-    buf[0] = input[*pos];
-    buf[1] = '\0';
+	buf[0] = input[*pos];
+	buf[1] = '\0';
 	old = *result;
-    *result = ft_strjoin(old, buf);
-    free(old);
-    (*pos)++;
+	*result = ft_strjoin(old, buf);
+	free(old);
+	(*pos)++;
 }
 
-char *expand_vars(const char *input, t_shell *sh)
+char	*expand_vars(const char *input, t_shell *sh)
 {
-    char   *result;
-    size_t  pos;
+	char	*result;
+	size_t	pos;
 
-    result = ft_strdup("");
-    if (!result)
-        return (NULL);
-
-    pos = 0;
-    while (input[pos])
-    {
-        if (input[pos] == '$')
-        {
-            if (handle_exit_status(input, &pos, &result, sh) == SUCCESS)
-                continue;
-            if (handle_env_var(input, &pos, &result, sh) == SUCCESS)
-                continue;
-			// ни $? ни $NAME — вставляем просто '$'
-            append_char_to_result(input, &pos, &result);
-        }
-        else
-        {
-			// любой другой символ
+	result = ft_strdup("");
+	if (!result)
+		return (NULL);
+	pos = 0;
+	while (input[pos])
+	{
+		if (input[pos] == '$')
+		{
+			if (handle_exit_status(input, &pos, &result, sh) == SUCCESS)
+				continue ;
+			if (handle_env_var(input, &pos, &result, sh) == SUCCESS)
+				continue ;
 			append_char_to_result(input, &pos, &result);
-        }
-    }
-    return (result);
+		}
+		else
+			append_char_to_result(input, &pos, &result);
+	}
+	return (result);
 }

--- a/src/parser/expand_vars.c
+++ b/src/parser/expand_vars.c
@@ -6,7 +6,7 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/26 13:42:50 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/05/26 19:29:11 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/05/26 19:45:36 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,7 @@
 #include "minishell.h"
 #include "env.h"
 #include <stdlib.h>
+#include "executor.h"
 
 static int  handle_exit_status(const char *input, size_t *i, char **res, t_shell *sh);
 static int  handle_env_var(const char *input, size_t *i, char **res, t_shell *sh);
@@ -35,102 +36,94 @@ static char *get_env_value(const char *var_name, t_env_list *env_list)
     return ("");
 }
 
-// Главная функция — сканирует строку и вызывает хендлеры:
+// 1) $?
+static int handle_exit_status(const char *input, size_t *pos, char **result, t_shell *sh)
+{
+    if (input[*pos + 1] != '?')
+        return (FAILURE);
+
+    char *status_str = ft_itoa(sh->last_status);
+    if (!status_str)
+        return (FAILURE);
+
+    char *tmp = *result;
+    *result = ft_strjoin(*result, status_str);
+    free(tmp);
+    free(status_str);
+
+    *pos += 2;
+    return (SUCCESS);
+}
+
+// 2) $NAME
+static int handle_env_var(const char *input, size_t *pos, char **result, t_shell *sh)
+{
+    size_t j = *pos + 1;
+    if (!(ft_isalnum((unsigned char)input[j]) || input[j] == '_'))
+        return (FAILURE);
+
+    while (input[j] && (ft_isalnum((unsigned char)input[j]) || input[j] == '_'))
+        j++;
+
+    char *var_name = ft_substr(input, *pos + 1, j - (*pos + 1));
+    if (!var_name)
+        return (FAILURE);
+
+    char *val = get_env_value(var_name, sh->env_list);
+    free(var_name);
+
+    char *tmp = *result;
+    *result = ft_strjoin(*result, val);
+    free(tmp);
+
+    *pos = j;
+    return (SUCCESS);
+}
+
+// 3) just symbol '$'
+static int handle_literal_dollar(const char *input, size_t *pos, char **result)
+{
+    char *tmp = *result;
+    
+    if (input[*pos] != '$')
+        return (FAILURE);
+    *result = ft_strjoin(tmp, "$");
+    free(tmp);
+
+    *pos += 1;
+    return (SUCCESS);
+}
+
 char *expand_vars(const char *input, t_shell *sh)
 {
     char   *result;
-    size_t  i;
+    size_t  pos;
 
     result = ft_strdup("");
     if (!result)
         return (NULL);
 
-    i = 0;
-    while (input[i])
+    pos = 0;
+    while (input[pos])
     {
-        if (input[i] == '$')
+        if (input[pos] == '$')
         {
-            if (handle_exit_status(input, &i, &result, sh))
+            if (handle_exit_status(input, &pos, &result, sh) == SUCCESS)
                 continue;
-            if (handle_env_var(input, &i, &result, sh))
+            if (handle_env_var(input, &pos, &result, sh) == SUCCESS)
                 continue;
-            if (handle_literal_dollar(input, &i, &result))
+            if (handle_literal_dollar(input, &pos, &result) == SUCCESS)
                 continue;
         }
         else
         {
-            // копируем обычный символ
-            char buf[2] = { input[i], '\0' };
+            char buf[2] = { input[pos], '\0' };
             char *tmp   = result;
 
             result = ft_strjoin(result, buf);
             free(tmp);
-            i++;
+            pos++;
         }
     }
     return (result);
-}
-
-// 1) $?
-static int handle_exit_status(const char *input, size_t *i, char **res, t_shell *sh)
-{
-    if (input[*i + 1] != '?')
-        return (0);
-
-    char *status_str = ft_itoa(sh->last_status);
-    if (!status_str)
-        return (0);
-
-    // result = result + status_str
-    char *tmp = *res;
-    *res = ft_strjoin(*res, status_str);
-    free(tmp);
-    free(status_str);
-
-    *i += 2;
-    return (1);
-}
-
-// 2) $NAME
-static int handle_env_var(const char *input, size_t *i, char **res, t_shell *sh)
-{
-    size_t j = *i + 1;
-
-    // проверяем, что за $ идёт допустимый первый символ имени
-    if (!(ft_isalnum((unsigned char)input[j]) || input[j] == '_'))
-        return (0);
-
-    // ищем конец имени
-    while (input[j] && (ft_isalnum((unsigned char)input[j]) || input[j] == '_'))
-        j++;
-
-    // вырезаем имя
-    char *var_name = ft_substr(input, *i + 1, j - (*i + 1));
-    if (!var_name)
-        return (0);
-
-    // ищем в вашем списке env
-    char *val = get_env_value(var_name, sh->env_list);
-    free(var_name);
-
-    // конкатенируем значение
-    char *tmp = *res;
-    *res = ft_strjoin(*res, val);
-    free(tmp);
-
-    *i = j;
-    return (1);
-}
-
-// 3) просто литерал '$'
-static int handle_literal_dollar(const char *input, size_t *i, char **res)
-{
-    (void)input;
-    // здесь мы гарантированно на input[*i] == '$'
-    char *tmp = *res;
-    *res = ft_strjoin(*res, "$");
-    free(tmp);
-
-    *i += 1;
-    return (1);
 }

--- a/src/parser/expand_vars.c
+++ b/src/parser/expand_vars.c
@@ -6,7 +6,7 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/26 13:42:50 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/05/26 19:45:36 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/05/26 19:55:30 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,6 +19,7 @@
 static int  handle_exit_status(const char *input, size_t *i, char **res, t_shell *sh);
 static int  handle_env_var(const char *input, size_t *i, char **res, t_shell *sh);
 static int  handle_literal_dollar(const char *input, size_t *i, char **res);
+static void append_char_to_result(const char *input, size_t *pos, char **result);
 static char *get_env_value(const char *var_name, t_env_list *env_list);
 
 static char *get_env_value(const char *var_name, t_env_list *env_list)
@@ -94,6 +95,19 @@ static int handle_literal_dollar(const char *input, size_t *pos, char **result)
     return (SUCCESS);
 }
 
+static void append_char_to_result(const char *input, size_t *pos, char **result)
+{
+    char    buf[2];
+    char   *tmp;
+
+    buf[0] = input[*pos];
+    buf[1] = '\0';
+    tmp = *result;
+    *result = ft_strjoin(*result, buf);
+    free(tmp);
+    (*pos)++;
+}
+
 char *expand_vars(const char *input, t_shell *sh)
 {
     char   *result;
@@ -117,12 +131,7 @@ char *expand_vars(const char *input, t_shell *sh)
         }
         else
         {
-            char buf[2] = { input[pos], '\0' };
-            char *tmp   = result;
-
-            result = ft_strjoin(result, buf);
-            free(tmp);
-            pos++;
+			append_char_to_result(input, &pos, &result);
         }
     }
     return (result);

--- a/src/parser/expand_vars.c
+++ b/src/parser/expand_vars.c
@@ -6,7 +6,7 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/26 13:42:50 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/05/26 19:55:30 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/05/26 20:04:18 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,7 +18,6 @@
 
 static int  handle_exit_status(const char *input, size_t *i, char **res, t_shell *sh);
 static int  handle_env_var(const char *input, size_t *i, char **res, t_shell *sh);
-static int  handle_literal_dollar(const char *input, size_t *i, char **res);
 static void append_char_to_result(const char *input, size_t *pos, char **result);
 static char *get_env_value(const char *var_name, t_env_list *env_list);
 
@@ -81,30 +80,16 @@ static int handle_env_var(const char *input, size_t *pos, char **result, t_shell
     return (SUCCESS);
 }
 
-// 3) just symbol '$'
-static int handle_literal_dollar(const char *input, size_t *pos, char **result)
-{
-    char *tmp = *result;
-    
-    if (input[*pos] != '$')
-        return (FAILURE);
-    *result = ft_strjoin(tmp, "$");
-    free(tmp);
-
-    *pos += 1;
-    return (SUCCESS);
-}
-
 static void append_char_to_result(const char *input, size_t *pos, char **result)
 {
     char    buf[2];
-    char   *tmp;
+    char   *old;
 
     buf[0] = input[*pos];
     buf[1] = '\0';
-    tmp = *result;
-    *result = ft_strjoin(*result, buf);
-    free(tmp);
+	old = *result;
+    *result = ft_strjoin(old, buf);
+    free(old);
     (*pos)++;
 }
 
@@ -126,11 +111,12 @@ char *expand_vars(const char *input, t_shell *sh)
                 continue;
             if (handle_env_var(input, &pos, &result, sh) == SUCCESS)
                 continue;
-            if (handle_literal_dollar(input, &pos, &result) == SUCCESS)
-                continue;
+			// ни $? ни $NAME — вставляем просто '$'
+            append_char_to_result(input, &pos, &result);
         }
         else
         {
+			// любой другой символ
 			append_char_to_result(input, &pos, &result);
         }
     }

--- a/src/parser/expand_vars.c
+++ b/src/parser/expand_vars.c
@@ -1,0 +1,131 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   expand_vars.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/05/26 13:42:50 by tsargsya          #+#    #+#             */
+/*   Updated: 2025/05/26 18:02:22 by tsargsya         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "libft.h"
+#include "minishell.h"
+#include "env.h"
+#include <stdlib.h>
+
+// Ищет переменную var_name в списке env_list.
+// Если находит — возвращает её value, иначе — пустую строку.
+char *get_env_value(const char *var_name, t_env_list *env_list)
+{
+    t_env_list *tmp = env_list;
+    size_t      len;
+
+    while (tmp)
+    {
+        len = ft_strlen(tmp->key);
+        // сравниваем полное совпадение ключа   
+        if (ft_strncmp(tmp->key, var_name, len + 1) == 0)
+            return tmp->value;
+        tmp = tmp->next;
+    }
+    return "";  // переменной нет — будем добавлять пустое
+}
+
+// Раскрывает все $VAR и $? внутри строки input.
+// input — нуль-терминированная строка без внешних кавычек.
+// Возвращает новую строку, которую нужно free() по завершении.
+char *expand_vars(const char *input, t_shell *sh)
+{
+    char    *result;
+    size_t   i;
+
+    // Инициализируем результат пустой строкой
+    result = ft_strdup("");
+    if (!result)
+        return (NULL);
+
+    i = 0;
+    while (input[i])
+    {
+        if (input[i] == '$')
+        {
+            // 1) Спец-переменная $?
+            if (input[i + 1] == '?')
+            {
+                char *status_str;
+                char *tmp;
+
+                status_str = ft_itoa(sh->last_status);
+                if (!status_str)
+                    return (free(result), NULL);
+
+                tmp = result;
+                result = ft_strjoin(result, status_str);
+                free(tmp);
+                free(status_str);
+
+                i += 2;
+            }
+            // 2) Обычная переменная $NAME
+            else if (ft_isalnum((unsigned char)input[i + 1]) 
+                     || input[i + 1] == '_')
+            {
+                size_t j = i + 1;
+                char  *var_name;
+                char  *val;
+                char  *tmp;
+
+                // найдём конец имени переменной
+                while (input[j] &&
+                       (ft_isalnum((unsigned char)input[j]) 
+                        || input[j] == '_'))
+                    j++;
+
+                // вырезаем имя переменной
+                var_name = ft_substr(input, i + 1, j - (i + 1));
+                if (!var_name)
+                    return (free(result), NULL);
+
+                // смотрим в вашем списке env
+                val = get_env_value(var_name, sh->env_list);
+                free(var_name);
+
+                // добавляем значение (или пустую строку)
+                tmp = result;
+                result = ft_strjoin(result, val);
+                free(tmp);
+
+                i = j;
+            }
+            // 3) не $?, не $LETTER — просто литерал '$'
+            else
+            {
+                char *tmp;
+
+                tmp = result;
+                result = ft_strjoin(result, "$");
+                free(tmp);
+                i++;
+            }
+        }
+        else
+        {
+            // Все прочие символы — копируем «как есть»
+            char buf[2];
+            char *tmp;
+
+            buf[0] = input[i];
+            buf[1] = '\0';
+            tmp = result;
+            result = ft_strjoin(result, buf);
+            free(tmp);
+            i++;
+        }
+    }
+
+    return (result);
+}
+
+

--- a/src/parser/lexer_utils.c
+++ b/src/parser/lexer_utils.c
@@ -6,14 +6,14 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/28 20:25:20 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/05/23 10:39:55 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/05/24 12:32:07 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "minishell.h"
-#include <stdlib.h>
 #include "libft.h"
+#include "minishell.h"
 #include <stdio.h>
+#include <stdlib.h>
 
 int	is_space(char c)
 {
@@ -51,18 +51,38 @@ void	print_tokens(t_token *tokens)
 {
 	while (tokens)
 	{
-		if (tokens->type == TOK_WORD)
-			printf("WORD: [%s]\n", tokens->value);
-		else if (tokens->type == TOK_PIPE)
-			printf("PIPE: [%s]\n", tokens->value);
-		else if (tokens->type == TOK_LESS)
-			printf("REDIR_IN: [%s]\n", tokens->value);
-		else if (tokens->type == TOK_GREATER)
-			printf("REDIR_OUT: [%s]\n", tokens->value);
-		else if (tokens->type == TOK_DLESS)
-			printf("HEREDOC: [%s]\n", tokens->value);
-		else if (tokens->type == TOK_DGREATER)
-			printf("APPEND: [%s]\n", tokens->value);
+		switch (tokens->type)
+		{
+		case TOK_WORD:
+			printf("WORD      : [%s]\n", tokens->value);
+			break ;
+		case TOK_SQUOTED:
+			printf("SQUOTED   : [%s]\n", tokens->value);
+			break ;
+		case TOK_DQUOTED:
+			printf("DQUOTED   : [%s]\n", tokens->value);
+			break ;
+		case TOK_PIPE:
+			printf("PIPE      : [%s]\n", tokens->value ? tokens->value : "|");
+			break ;
+		case TOK_LESS:
+			printf("REDIR_IN  : [%s]\n", tokens->value ? tokens->value : "<");
+			break ;
+		case TOK_GREATER:
+			printf("REDIR_OUT : [%s]\n", tokens->value ? tokens->value : ">");
+			break ;
+		case TOK_DLESS:
+			printf("HEREDOC   : [%s]\n", tokens->value ? tokens->value : "<<");
+			break ;
+		case TOK_DGREATER:
+			printf("APPEND    : [%s]\n", tokens->value ? tokens->value : ">>");
+			break ;
+		default:
+			printf("UNKNOWN(%d): [%s]\n",
+					tokens->type,
+					tokens->value ? tokens->value : "");
+			break ;
+		}
 		tokens = tokens->next;
 	}
 }

--- a/src/parser/lexer_utils.c
+++ b/src/parser/lexer_utils.c
@@ -6,11 +6,12 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/28 20:25:20 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/05/24 12:32:07 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/05/26 20:18:12 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
+#include "parser.h"
 #include "minishell.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -49,6 +50,7 @@ void	add_token(t_token **tokens, t_token_type type, char *value)
 
 void	print_tokens(t_token *tokens)
 {
+	printf(YELLOW "TOKENS:\n" RESET);
 	while (tokens)
 	{
 		switch (tokens->type)

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/30 14:58:43 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/05/23 18:00:44 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/05/26 10:58:14 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -126,6 +126,11 @@ void	free_cmd_list(t_cmd *cmd)
 	}
 }
 
+int	is_arg_token(t_token_type type)
+{
+	return (type == TOK_WORD || type == TOK_SQUOTED || type == TOK_DQUOTED);
+}
+
 t_cmd	*parse_tokens(t_token *tokens)
 {
 	t_cmd	*cmd;
@@ -137,12 +142,12 @@ t_cmd	*parse_tokens(t_token *tokens)
 	current_cmd = cmd;
 	while (tokens)
 	{
-		if (tokens->type == TOK_WORD)
+		if (is_arg_token(tokens->type))
 			append_arg(current_cmd, tokens->value);
 		else if (tokens->type == TOK_LESS || tokens->type == TOK_GREATER
 			|| tokens->type == TOK_DLESS || tokens->type == TOK_DGREATER)
 		{
-			if (!tokens->next || tokens->next->type != TOK_WORD)
+			if (!tokens->next || !is_arg_token(tokens->next->type))
 			{
 				printf("minishell: syntax error near `%s'\n", tokens->value);
 				free_cmd_list(cmd);
@@ -175,7 +180,7 @@ t_cmd	*parse_tokens(t_token *tokens)
 				free_cmd_list(cmd);
 				return (NULL);
 			}
-			if (!tokens->next || tokens->next->type != TOK_WORD)
+			if (!tokens->next || !is_arg_token(tokens->next->type))
 			{
 				printf("minishell: syntax error near unexpected token ");
 				if (!tokens->next)

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/30 14:58:43 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/05/26 13:47:18 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/05/26 20:18:35 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -229,6 +229,7 @@ void	print_cmds(t_cmd *cmd)
 	t_redir	*redir;
 
 	cmd_num = 1;
+	printf(YELLOW "COMMANDS:\n" RESET);
 	while (cmd)
 	{
 		printf("Command %d:\n", cmd_num++);
@@ -258,4 +259,5 @@ void	print_cmds(t_cmd *cmd)
 		}
 		cmd = cmd->next;
 	}
+		printf("\n");
 }

--- a/src/readline_loop.c
+++ b/src/readline_loop.c
@@ -6,7 +6,7 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/28 19:02:03 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/05/23 22:37:25 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/05/26 18:05:24 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,7 +39,7 @@ void	readline_loop(t_shell *sh)
 			// print_tokens(tokens);
 			if (tokens)
 			{
-				cmd = parse_tokens(tokens);
+				cmd = parse_tokens(tokens, sh);
 				// print_cmds(cmd);
 			}
 			if (cmd)


### PR DESCRIPTION
This pull request introduces significant updates to the Minishell project, focusing on adding support for variable expansion and improving the handling of quoted strings. Key changes include the implementation of a new `expand_vars` function, updates to the lexer and parser to handle single and double quotes, and enhancements to the debugging output for tokens and commands.

### Variable Expansion and Quoting Enhancements:
* Added a new `expand_vars` function in `src/parser/expand_vars.c` to handle environment variable expansion and special cases like `$?` for the last exit status.
* Updated the lexer in `src/parser/lexer.c` to tokenize single-quoted (`TOK_SQUOTED`) and double-quoted (`TOK_DQUOTED`) strings, and added functions `read_squoted` and `read_dquoted` for handling quoted tokens. [[1]](diffhunk://#diff-14136e83d653d752e7b1d8807b3040b0fe845c5d3b764ea9036315b0352bb684R64-R97) [[2]](diffhunk://#diff-14136e83d653d752e7b1d8807b3040b0fe845c5d3b764ea9036315b0352bb684L128-R128)
* Modified the parser in `src/parser/parser.c` to process `TOK_SQUOTED` and `TOK_DQUOTED` tokens, expanding variables for double-quoted and unquoted strings while preserving literals for single-quoted strings. [[1]](diffhunk://#diff-a07f146eb89913dc369f69ee0108bc864842ce31211a05b121e5c3c432cdb16eL129-R184) [[2]](diffhunk://#diff-a07f146eb89913dc369f69ee0108bc864842ce31211a05b121e5c3c432cdb16eL178-R194)

### Debugging and Readability Improvements:
* Enhanced token printing in `src/parser/lexer_utils.c` to include new token types (`TOK_SQUOTED` and `TOK_DQUOTED`) with color-coded output for better debugging.
* Improved command printing in `src/parser/parser.c` with color-coded headers and better formatting for debugging purposes. [[1]](diffhunk://#diff-a07f146eb89913dc369f69ee0108bc864842ce31211a05b121e5c3c432cdb16eR232) [[2]](diffhunk://#diff-a07f146eb89913dc369f69ee0108bc864842ce31211a05b121e5c3c432cdb16eR262)

### Updates to Project Files:
* Added `parser/expand_vars.c` to the `Makefile` for compilation.
* Expanded the `README.md` with new test cases for quotes and variable expansion, providing clear expectations for behavior and edge cases.

### Other Changes:
* Updated headers in multiple files to reflect the latest modification dates. [[1]](diffhunk://#diff-471850465338484d65e05947dade7a795e3e068ed9502a098e77c91b5ac1582fL9-R9) [[2]](diffhunk://#diff-3b2df7c1bd222e92cf09a90765c2c75bf7353069fd6ff0ea90b4d5a280d0823bL9-R9) [[3]](diffhunk://#diff-14136e83d653d752e7b1d8807b3040b0fe845c5d3b764ea9036315b0352bb684L9-R9) [[4]](diffhunk://#diff-70f0b768520ef6d022e830a40c14d7396c37c04829f3b847df2bd5f171756ac8L9-R17) [[5]](diffhunk://#diff-a07f146eb89913dc369f69ee0108bc864842ce31211a05b121e5c3c432cdb16eL9-R9) [[6]](diffhunk://#diff-3c638e877f20879eafb4f7f8d7f548b03ff36391d3b5498288898bd67ac6ace6L9-R9)
* Added color definitions (e.g., `RED`, `GREEN`, `YELLOW`) in `include/parser.h` for use in debugging output.