### PR TITLE
Fix/echo remove expansion

### DIFF
--- a/src/builtin/builtin_echo.c
+++ b/src/builtin/builtin_echo.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   builtin_echo.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: denissemenov <denissemenov@student.42.f    +#+  +:+       +#+        */
+/*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/29 18:02:24 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/05/27 00:53:18 by denissemeno      ###   ########.fr       */
+/*   Updated: 2025/05/27 13:53:53 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,7 +29,7 @@ static int	is_arg_n(const char *arg)
 	return (1);
 }
 
-static void	print_args(char **argv, t_env_list **env)
+static void	print_args(char **argv)
 {
 	while (*argv != NULL)
 	{
@@ -45,6 +45,7 @@ int	builtin_echo(t_cmd *cmd, t_env_list **env)
 {
 	char	**argv;
 	int		has_n_arg;
+	(void) env;
 
 	argv = cmd->args + 1;
 	has_n_arg = 0;
@@ -60,7 +61,7 @@ int	builtin_echo(t_cmd *cmd, t_env_list **env)
 		//TODO: check security
 		return (0);
 	}
-	print_args(argv, env);
+	print_args(argv);
 	if (has_n_arg == 0)
 		printf("\n");
 	//TODO: check security

--- a/src/executor/executor_utils.c
+++ b/src/executor/executor_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   executor_utils.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
+/*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/12 10:19:46 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/05/23 22:56:23 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/05/27 13:54:06 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -65,6 +65,7 @@ static int	apply_one_redir(t_redir *redir)
 	int	fd;
 	int	ret;
 
+	fd = -1;
 	if (redir->type == REDIR_HEREDOC)
 		return (handle_heredoc(redir));
 	// 2) open the file with the required mode


### PR DESCRIPTION
This pull request includes changes to the `builtin_echo` functionality and minor updates to the `executor_utils` file. The most significant updates involve removing support for environment variable expansion in `builtin_echo` and cleaning up unused parameters.

### Changes to `builtin_echo`:

* Removed the `print_env` function, which previously handled environment variable expansion for ` prefixed arguments. This change simplifies the code but eliminates the ability to expand environment variables in `builtin_echo`.
* Modified the `print_args` function to no longer check for ` prefixed arguments or call `print_env`, further reflecting the removal of environment variable expansion.
* Updated the `builtin_echo` function to remove the dependency on the `env` parameter, marking it unused with `(void) env`.
* Adjusted the `builtin_echo` function to call the updated `print_args` function without passing the `env` parameter.

### Miscellaneous updates:

* Updated the author and timestamp metadata in the file headers of `builtin_echo.c` and `executor_utils.c` to reflect the new author, `dsemenov`. [[1]](diffhunk://#diff-17190236076e15d22bf53c4e2964cad8da3d467997a3bf2ea7863a111a00ebddL6-R9) [[2]](diffhunk://#diff-77ef3155698f8836019d015f2146c903b44c51d8699f9d750324abb59d7b4357L6-R9)
* Added an initialization for the `fd` variable in the `apply_one_redir` function in `executor_utils.c` to ensure it is explicitly set to `-1`.