### PR TITLE
refactor: some changes

### DIFF
--- a/src/builtin/builtin_export.c
+++ b/src/builtin/builtin_export.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   builtin_export.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
+/*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/05 17:52:15 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/05/22 19:49:49 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/05/27 15:24:08 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,27 +18,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-static int	is_in_envlist(t_env_list **env, char *name, char *value)
+static void	free_key_value(char *key, char *value)
 {
-	t_env_list	*tmp;
-
-	tmp = *env;
-	while (tmp)
-	{
-		if (ft_strcmp(tmp->key, name) == 0)
-		{
-			free(tmp->value);
-			tmp->value = ft_strdup(value);
-			if (tmp->value == NULL)
-			{
-				perror("malloc");
-				return (-1);
-			}
-			return (1);
-		}
-		tmp = tmp->next;
-	}
-	return (0);
+	if (key)
+		free(key);
+	if (value)
+		free(value);
 }
 
 static int	export_without_args(t_env_list **env)
@@ -66,47 +51,47 @@ static char	*find_equal_sign(const char *arg)
 	return (equality_sign);
 }
 
-//Check multiple args
+// Check multiple args
 int	builtin_export(t_cmd *cmd, t_env_list **env)
 {
 	t_env_list	*new_node;
+	t_env_list	*tmp_node;
 	char		*equality_sign;
 	char		*key;
 	char		*value;
-	int			ret;
 
 	if (cmd->args[1] == NULL)
 		return (export_without_args(env));
 	if ((equality_sign = find_equal_sign(cmd->args[1])) == NULL)
 		return (0);
-	key = ft_substr(cmd->args[1], 0, equality_sign - cmd->args[1]);
+	if ((key = ft_substr(cmd->args[1], 0, equality_sign
+				- cmd->args[1])) == NULL)
+	{
+		perror("minishell");
+		return (1);
+	}
 	value = ft_strdup(++equality_sign);
-	if (key == NULL || value == NULL)
+	if (!value)
 	{
-		perror("malloc");
+		perror("minishell");
 		free(key);
-		free(value);
 		return (1);
 	}
-	ret = is_in_envlist(env, key, value);
-	if (ret < 0)
+	tmp_node = find_node_by_key(env, key);
+	if (tmp_node)
 	{
-		free(key);
-		free(value);
-		return (1);
-	}
-	else if (ret == 1)
-	{
-		free(key);
-		free(value);
+		set_value(tmp_node, value);
+		free_key_value(key, value);
 		return (0);
 	}
-	if ((new_node = lst_create_node(key, value)) == NULL)
+	else
 	{
-		perror("malloc");
-		free(key);
-		free(value);
-		return (1);
+		if ((new_node = lst_create_node(key, value)) == NULL)
+		{
+			perror("malloc");
+			free_key_value(key, value);
+			return (1);
+		}
 	}
 	lst_add_end(env, new_node);
 	return (0);


### PR DESCRIPTION
This pull request refactors the `builtin_export.c` file to improve memory management and simplify the logic for handling environment variables. Key changes include replacing a complex function with a more modular approach, improving error handling, and updating the file's metadata.

### Refactoring and Memory Management:

* Replaced the `is_in_envlist` function with a new helper function `free_key_value`, simplifying the code and improving memory management by centralizing key-value pair deallocation. (`src/builtin/builtin_export.c`, [src/builtin/builtin_export.cL21-R26](diffhunk://#diff-1d323fa3ae3bee94c06f2ddfaa91331f4a62f8ee2186857241822650247a06c9L21-R26))
* Updated the `builtin_export` function to use `find_node_by_key` and `set_value` for modifying existing environment variables, improving readability and maintainability. (`src/builtin/builtin_export.c`, [src/builtin/builtin_export.cR58-R95](diffhunk://#diff-1d323fa3ae3bee94c06f2ddfaa91331f4a62f8ee2186857241822650247a06c9R58-R95))

### Error Handling:

* Enhanced error messages in `builtin_export` to specify "minishell" as the source of errors, providing better context for debugging. (`src/builtin/builtin_export.c`, [src/builtin/builtin_export.cR58-R95](diffhunk://#diff-1d323fa3ae3bee94c06f2ddfaa91331f4a62f8ee2186857241822650247a06c9R58-R95))

### Metadata Update:

* Updated the file header to reflect the new author (`dsemenov`) and the latest modification date. (`src/builtin/builtin_export.c`, [src/builtin/builtin_export.cL6-R9](diffhunk://#diff-1d323fa3ae3bee94c06f2ddfaa91331f4a62f8ee2186857241822650247a06c9L6-R9))