### PR TITLE
feature: handle multiple arguments in export. Comment out free_cmd_li…

### DIFF
--- a/src/builtin/builtin_export.c
+++ b/src/builtin/builtin_export.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/05 17:52:15 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/05/27 15:24:08 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/05/27 18:43:04 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,21 +51,21 @@ static char	*find_equal_sign(const char *arg)
 	return (equality_sign);
 }
 
-// Check multiple args
-int	builtin_export(t_cmd *cmd, t_env_list **env)
+static int export_argument(char **argv, t_env_list **env)
 {
-	t_env_list	*new_node;
-	t_env_list	*tmp_node;
 	char		*equality_sign;
 	char		*key;
 	char		*value;
-
-	if (cmd->args[1] == NULL)
-		return (export_without_args(env));
-	if ((equality_sign = find_equal_sign(cmd->args[1])) == NULL)
+	t_env_list	*new_node;
+	t_env_list	*tmp_node;
+	
+	if ((equality_sign = find_equal_sign(*argv)) == NULL)
+	{
+		argv++;
 		return (0);
-	if ((key = ft_substr(cmd->args[1], 0, equality_sign
-				- cmd->args[1])) == NULL)
+	}
+	if ((key = ft_substr(*argv, 0, equality_sign
+				- *argv)) == NULL)
 	{
 		perror("minishell");
 		return (1);
@@ -82,7 +82,6 @@ int	builtin_export(t_cmd *cmd, t_env_list **env)
 	{
 		set_value(tmp_node, value);
 		free_key_value(key, value);
-		return (0);
 	}
 	else
 	{
@@ -92,7 +91,23 @@ int	builtin_export(t_cmd *cmd, t_env_list **env)
 			free_key_value(key, value);
 			return (1);
 		}
+		lst_add_end(env, new_node);
 	}
-	lst_add_end(env, new_node);
+	return (0);
+}
+
+// Check multiple args
+int	builtin_export(t_cmd *cmd, t_env_list **env)
+{
+	char		**argv;
+
+	if (cmd->args[1] == NULL)
+		return (export_without_args(env));
+	argv = ++cmd->args;
+	while (*argv)
+	{
+		export_argument(argv, env);
+		argv++;
+	}
 	return (0);
 }

--- a/src/executor/executor.c
+++ b/src/executor/executor.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   executor.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
+/*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/06 12:38:33 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/05/23 19:46:48 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/05/27 18:25:56 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -72,6 +72,6 @@ void	executor(t_cmd *cmd, t_shell *sh)
 	}
 	else
 		execute_cmds(cmd, sh);
-	free_cmd_list(cmd);
+	//free_cmd_list(cmd); TODO: Fix double free crash (export TMP=HELLO)
 	free_env_tab(sh->env_tab);
 }


### PR DESCRIPTION
…st in executor.c because of crash (double free). Need to be fixed
This pull request refactors the `builtin_export` function to improve modularity and maintainability, while also addressing a potential double free issue in the `executor` function. Below are the key changes grouped by theme:

### Refactoring and Modularization of `builtin_export`:

* Extracted a new helper function `export_argument` to handle the processing of individual arguments, improving code readability and modularity.
* Updated the `builtin_export` function to iterate through multiple arguments and call the new `export_argument` function for each, simplifying the logic for handling multiple inputs.

### Bug Fix in `executor`:

* Commented out the `free_cmd_list` call in the `executor` function to prevent a double free crash when exporting variables (e.g., `export TMP=HELLO`). Added a `TODO` comment for further investigation.

### Metadata Updates:

* Updated file headers in `builtin_export.c` and `executor.c` to reflect the latest modification timestamps and authorship changes. [[1]](diffhunk://#diff-1d323fa3ae3bee94c06f2ddfaa91331f4a62f8ee2186857241822650247a06c9L9-R9) [[2]](diffhunk://#diff-a55a4faa58d161ee67291f2f04bfb06c03009af38cabdeeb1510eef95cdf159cL6-R9)