### PR TITLE
refactor: extract key-value parsing logic into separate function

### DIFF
--- a/src/builtin/builtin_export.c
+++ b/src/builtin/builtin_export.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/05 17:52:15 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/05/27 19:19:27 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/05/27 20:25:44 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,16 +56,33 @@ static int	export_argument(char *key, char *value, t_env_list **env)
 	}
 	return (0);
 }
+int	parse_key_value(char *arg, char **key, char **value, char *equality_sign)
+{
+	if ((*key = ft_substr(arg, 0, equality_sign - arg)) == NULL)
+	{
+		perror("minishell");
+		return (1);
+	}
+	*value = ft_strdup(++equality_sign);
+	if (*value == NULL)
+	{
+		perror("minishell");
+		free(*key);
+		return (1);
+	}
+	return (0);
+}
 
 // Check multiple args
 int	builtin_export(t_cmd *cmd, t_env_list **env)
 {
-	t_env_list	*node;
-	char		**argv;
-	char		*equality_sign;
-	char		*key;
-	char		*value;
+	char	**argv;
+	char	*equality_sign;
+	char	*key;
+	char	*value;
 
+	key = NULL;
+	value = NULL;
 	if (cmd->args[1] == NULL)
 		return (export_without_args(env));
 	argv = ++cmd->args;
@@ -76,20 +93,8 @@ int	builtin_export(t_cmd *cmd, t_env_list **env)
 			argv++;
 			continue ;
 		}
-		if ((key = ft_substr(*argv, 0, equality_sign - *argv)) == NULL)
-		{
-			perror("minishell");
+		if (parse_key_value(*argv, &key, &value, equality_sign) == 1)
 			return (1);
-		}
-		value = ft_strdup(++equality_sign);
-		if (value == NULL)
-		{
-			perror("minishell");
-			free(key);
-			return (1);
-		}
-		if ((node = find_node_by_key(env, key)) != NULL)
-			set_value(node, value);
 		export_argument(key, value, env);
 		argv++;
 	}


### PR DESCRIPTION
This pull request refactors the `builtin_export` function in `src/builtin/builtin_export.c` to improve code reusability and readability by introducing a new helper function, `parse_key_value`. The helper function centralizes the logic for parsing key-value pairs, reducing duplication and simplifying the main function.

### Refactoring for code reusability:

* Added a new helper function `parse_key_value` to handle parsing of key-value pairs from an argument string. This function extracts the key and value, handles memory allocation, and includes error handling for allocation failures. (`[src/builtin/builtin_export.cR59-R85](diffhunk://#diff-1d323fa3ae3bee94c06f2ddfaa91331f4a62f8ee2186857241822650247a06c9R59-R85)`)
* Replaced the inlined key-value parsing logic in `builtin_export` with a call to the new `parse_key_value` function, reducing code duplication and improving clarity. (`[src/builtin/builtin_export.cL79-L92](diffhunk://#diff-1d323fa3ae3bee94c06f2ddfaa91331f4a62f8ee2186857241822650247a06c9L79-L92)`)

### Other changes:

* Updated the timestamp in the file header comment to reflect the latest modification. (`[src/builtin/builtin_export.cL9-R9](diffhunk://#diff-1d323fa3ae3bee94c06f2ddfaa91331f4a62f8ee2186857241822650247a06c9L9-R9)`)