### PR TITLE
hotfix: change or with and in readline_loop check for empty or whites…

### DIFF
--- a/src/readline_loop.c
+++ b/src/readline_loop.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   readline_loop.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
+/*   By: denissemenov <denissemenov@student.42.f    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/28 19:02:03 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/05/30 21:24:04 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/05/31 02:32:04 by denissemeno      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,6 +24,7 @@ static int	is_only_whitespaces(char *input)
 	{
 		if (is_space(*input) == 0)
 			return (0);
+		input++;
 	}
 	return (1);
 }
@@ -37,7 +38,7 @@ void	readline_loop(t_shell *sh)
 	setup_signal_handlers();
 	while ((input = readline("minishell > ")) != NULL)
 	{
-		if (input[0] != '\0' || !is_only_whitespaces(input))
+		if (input[0] != '\0' && !is_only_whitespaces(input))
 			// TODO: check if input is empty and if input is only spaces
 		{
 			if (ft_strncmp(input, "exit", 5) == 0)


### PR DESCRIPTION
This pull request includes updates to the `src/readline_loop.c` file, addressing a bug in whitespace handling, improving code correctness, and updating metadata in the file header.

### Bug Fixes:
* Fixed a logic error in the `readline_loop` function by changing the condition to correctly check that the input is non-empty and not only whitespace. This resolves an issue where inputs consisting solely of whitespace were incorrectly processed. (`[src/readline_loop.cL40-R41](diffhunk://#diff-3c638e877f20879eafb4f7f8d7f548b03ff36391d3b5498288898bd67ac6ace6L40-R41)`)

### Code Correctness:
* Added a missing `input++` in the `is_only_whitespaces` function to ensure the pointer advances during the loop, preventing potential infinite loops or incorrect behavior. (`[src/readline_loop.cR27](diffhunk://#diff-3c638e877f20879eafb4f7f8d7f548b03ff36391d3b5498288898bd67ac6ace6R27)`)

### Metadata Updates:
* Updated the file header to reflect changes in the author's name and email, as well as the last updated timestamp. (`[src/readline_loop.cL6-R9](diffhunk://#diff-3c638e877f20879eafb4f7f8d7f548b03ff36391d3b5498288898bd67ac6ace6L6-R9)`)