### PR TITLE
Fix unclosed quotes

### DIFF
--- a/src/parser/lexer.c
+++ b/src/parser/lexer.c
@@ -6,7 +6,7 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/28 16:33:07 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/05/31 20:21:27 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/06/02 15:49:41 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -72,6 +72,7 @@ static int	read_squoted(t_token **tokens, char *input, int *i, int sep_flag)
 	if (input[*i] != '\'')
 	{
 		// TODO: handle unclosed single quote
+		printf("minishell: syntax error: unclosed single quote\n");
 		return (1);
 	}
 	add_token(tokens, TOK_SQUOTED, ft_strndup(input + start, *i - start),
@@ -90,6 +91,7 @@ static int	read_dquoted(t_token **tokens, char *input, int *i, int sep_flag)
 	if (input[*i] != '"')
 	{
 		// TODO: handle unclosed double quote
+		printf("minishell: syntax error: unclosed double quote\n");
 		return (1);
 	}
 	add_token(tokens, TOK_DQUOTED, ft_strndup(input + start, *i - start),
@@ -136,13 +138,13 @@ t_token	*lexer(char *input)
 			}
 			else if (input[i] == '\'')
 			{
-				if (read_squoted(&tokens, input, &i, sep_flag))
+				if (read_squoted(&tokens, input, &i, sep_flag) == 1)
 					return (free_tokens(tokens), NULL);
 				last_was_space = 0;
 			}
 			else if (input[i] == '"')
 			{
-				if (read_dquoted(&tokens, input, &i, sep_flag))
+				if (read_dquoted(&tokens, input, &i, sep_flag) == 1)
 					return (free_tokens(tokens), NULL);
 				last_was_space = 0;
 			}

--- a/src/parser/lexer.c
+++ b/src/parser/lexer.c
@@ -6,7 +6,7 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/28 16:33:07 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/06/02 15:49:41 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/06/02 16:15:35 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -71,7 +71,6 @@ static int	read_squoted(t_token **tokens, char *input, int *i, int sep_flag)
 		(*i)++;
 	if (input[*i] != '\'')
 	{
-		// TODO: handle unclosed single quote
 		printf("minishell: syntax error: unclosed single quote\n");
 		return (1);
 	}
@@ -90,7 +89,6 @@ static int	read_dquoted(t_token **tokens, char *input, int *i, int sep_flag)
 		(*i)++;
 	if (input[*i] != '"')
 	{
-		// TODO: handle unclosed double quote
 		printf("minishell: syntax error: unclosed double quote\n");
 		return (1);
 	}

--- a/src/readline_loop.c
+++ b/src/readline_loop.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   readline_loop.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: denissemenov <denissemenov@student.42.f    +#+  +:+       +#+        */
+/*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/28 19:02:03 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/05/31 02:32:04 by denissemeno      ###   ########.fr       */
+/*   Updated: 2025/06/02 16:05:40 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,7 +39,6 @@ void	readline_loop(t_shell *sh)
 	while ((input = readline("minishell > ")) != NULL)
 	{
 		if (input[0] != '\0' && !is_only_whitespaces(input))
-			// TODO: check if input is empty and if input is only spaces
 		{
 			if (ft_strncmp(input, "exit", 5) == 0)
 			{
@@ -48,15 +47,18 @@ void	readline_loop(t_shell *sh)
 			}
 			add_history(input);
 			tokens = lexer(input);
-			print_tokens(tokens);
 			if (tokens)
 			{
+				print_tokens(tokens);
 				cmd = parse_tokens(tokens, sh);
-				// print_cmds(cmd);
+				if (cmd)
+				{
+					// print_cmds(cmd);
+					executor(cmd, sh);
+					free_cmd_list(cmd);
+				}
+				free_tokens(tokens);
 			}
-			if (cmd)
-				executor(cmd, sh);
-			free_tokens(tokens);
 		}
 		free(input);
 	}


### PR DESCRIPTION
This pull request addresses several improvements and fixes in the `src/parser/lexer.c` and `src/readline_loop.c` files to enhance error handling, streamline code execution, and update metadata. The most significant changes include adding explicit error messages for unclosed quotes, refining the return value checks in the lexer function, and cleaning up redundant or commented-out code in the readline loop.

### Error Handling Improvements:
* [`src/parser/lexer.c`](diffhunk://#diff-14136e83d653d752e7b1d8807b3040b0fe845c5d3b764ea9036315b0352bb684L74-R74): Added explicit error messages for unclosed single and double quotes using `printf` to improve user feedback during syntax errors. [[1]](diffhunk://#diff-14136e83d653d752e7b1d8807b3040b0fe845c5d3b764ea9036315b0352bb684L74-R74) [[2]](diffhunk://#diff-14136e83d653d752e7b1d8807b3040b0fe845c5d3b764ea9036315b0352bb684L92-R92)

### Code Refinements:
* [`src/parser/lexer.c`](diffhunk://#diff-14136e83d653d752e7b1d8807b3040b0fe845c5d3b764ea9036315b0352bb684L139-R145): Updated the `lexer` function to explicitly compare the return value of `read_squoted` and `read_dquoted` against `1`, ensuring accurate handling of error conditions.
* [`src/readline_loop.c`](diffhunk://#diff-3c638e877f20879eafb4f7f8d7f548b03ff36391d3b5498288898bd67ac6ace6L51-R62): Moved the `print_tokens` function call inside the conditional block where tokens are processed, and cleaned up commented-out code for better readability and maintainability.

### Metadata Updates:
* `src/parser/lexer.c` and `src/readline_loop.c`: Updated file headers to reflect the latest modification date and the author responsible for the changes. [[1]](diffhunk://#diff-14136e83d653d752e7b1d8807b3040b0fe845c5d3b764ea9036315b0352bb684L9-R9) [[2]](diffhunk://#diff-3c638e877f20879eafb4f7f8d7f548b03ff36391d3b5498288898bd67ac6ace6L6-R9)