### PR TITLE
feature: handle input as directory

### DIFF
--- a/include/executor.h
+++ b/include/executor.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   executor.h                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
+/*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/06 12:39:30 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/05/23 22:09:37 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/06/02 17:50:48 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,9 +49,10 @@ void					execute_child(t_cmd *cmd, t_shell *sh);
 int						handle_redirections(t_cmd *cmd);
 
 // exit_utils.c
+int						is_directory(char *cmd);
 void					error_exit(char *msg);
 
-//signals.c
+// signals.c
 void					setup_signal_handlers(void);
 
 #endif

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
+/*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/27 14:09:40 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/05/24 11:48:16 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/06/02 18:10:24 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,7 +54,6 @@ void						print_tokens(t_token *tokens);
 void						free_tokens(t_token *tokens);
 
 // readline_loop.c
-typedef struct s_env_list	t_env_list;
 void						readline_loop(t_shell *sh);
 
 #endif

--- a/src/readline_loop.c
+++ b/src/readline_loop.c
@@ -3,20 +3,35 @@
 /*                                                        :::      ::::::::   */
 /*   readline_loop.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
+/*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/28 19:02:03 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/05/30 16:10:53 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/06/02 18:01:51 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "executor.h"
-#include "minishell.h"
+#include "ft_printf.h"
 #include "libft.h"
+#include "minishell.h"
 #include "parser.h"
 #include <readline/history.h>
 #include <readline/readline.h>
 #include <stdlib.h>
+
+int	is_directory(char *cmd)
+{
+	size_t	len;
+
+	len = ft_strlen(cmd);
+	if (((cmd[len - 1] == '.') || (cmd[len - 1] == '/')) || (cmd[0] == '.'
+			&& cmd[1] == '\0'))
+	{
+		ft_dprintf(2, "minishell: %s: Is a directory\n", cmd);
+		return (1);
+	}
+	return (0);
+}
 
 void	readline_loop(t_shell *sh)
 {
@@ -27,7 +42,8 @@ void	readline_loop(t_shell *sh)
 	setup_signal_handlers();
 	while ((input = readline("minishell > ")) != NULL)
 	{
-		if (input[0] != '\0') // TODO: check if input is empty and if input is only spaces
+		if (input[0] != '\0')
+		// TODO: check if input is empty and if input is only spaces
 		{
 			if (ft_strncmp(input, "exit", 5) == 0)
 			{
@@ -40,6 +56,12 @@ void	readline_loop(t_shell *sh)
 			if (tokens)
 			{
 				cmd = parse_tokens(tokens, sh);
+				if (is_directory(cmd->args[0]))
+				{
+					sh->last_status = 126;
+					free(input);
+					continue ;
+				}
 				// print_cmds(cmd);
 			}
 			if (cmd)


### PR DESCRIPTION
This pull request introduces several updates to the `minishell` project, including a new utility function, adjustments to existing logic in the `readline_loop`, and minor organizational changes. The most significant addition is the implementation of the `is_directory` function to handle cases where a command is mistakenly a directory. Below are the key changes grouped by theme:

### New Functionality
* Added the `is_directory` function in `src/readline_loop.c` to check if a given command is a directory. If it is, an error message is printed, and the function returns an error code. This function is also declared in `include/executor.h`. [[1]](diffhunk://#diff-ebeeb1fe20145bf0170ddb0dec8614a326c3861d14571e10e490aec2bc6752c5R52) [[2]](diffhunk://#diff-3c638e877f20879eafb4f7f8d7f548b03ff36391d3b5498288898bd67ac6ace6L6-R35)

### Updates to `readline_loop` Logic
* Integrated the `is_directory` function into the `readline_loop` to prevent execution of directory paths. If the first argument of a parsed command is a directory, the shell sets the last status to `126`, frees the input, and skips further processing.
* Adjusted a comment in the `readline_loop` to clarify a TODO related to input validation.

### Header and Include File Adjustments
* Updated author information in the headers of `executor.h`, `minishell.h`, and `readline_loop.c` to reflect the new contributor `dsemenov`. [[1]](diffhunk://#diff-ebeeb1fe20145bf0170ddb0dec8614a326c3861d14571e10e490aec2bc6752c5L6-R9) [[2]](diffhunk://#diff-471850465338484d65e05947dade7a795e3e068ed9502a098e77c91b5ac1582fL6-R9) [[3]](diffhunk://#diff-3c638e877f20879eafb4f7f8d7f548b03ff36391d3b5498288898bd67ac6ace6L6-R35)
* Reordered includes in `src/readline_loop.c` to ensure `ft_printf.h` is included before `minishell.h`.

### Code Cleanup
* Removed an unused typedef for `t_env_list` in `include/minishell.h`.