### PR TITLE
feature: implement correct exit behavior. Need to implement exit status and freeing input

### DIFF
--- a/src/builtin/builtin_exit.c
+++ b/src/builtin/builtin_exit.c
@@ -6,17 +6,29 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/05 17:52:06 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/05/15 16:15:21 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/02 20:09:42 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "env.h"
 #include "builtins.h"
+#include "env.h"
+#include "ft_printf.h"
+#include "libft.h"
 #include "parser.h"
+#include <stdlib.h>
 
+
+//TODO: Handle exit status code overflow
 int	builtin_exit(t_cmd *cmd, t_env_list **env)
 {
-	(void)cmd;
-	(void)env;
+	lst_clear(env);
+	if (cmd->args[1] == NULL)
+		exit(0);
+	else
+	{
+		if (cmd->args[2])
+			ft_dprintf(2, "exit\nminishell: exit: too many arguments\n");
+		exit(ft_atoi(cmd->args[1]));
+	}
 	return (0);
 }

--- a/src/readline_loop.c
+++ b/src/readline_loop.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/28 19:02:03 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/02 18:01:51 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/02 19:34:54 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,11 +55,6 @@ void	readline_loop(t_shell *sh)
 	{
 		if (input[0] != '\0' && !is_only_whitespaces(input))
 		{
-			if (ft_strncmp(input, "exit", 5) == 0)
-			{
-				free(input);
-				break ;
-			}
 			add_history(input);
 			tokens = lexer(input);
 			if (tokens)


### PR DESCRIPTION
This pull request introduces significant updates to the `builtin_exit` function and modifies the behavior of the `readline_loop` function. The changes aim to improve functionality and error handling in the shell's exit command while simplifying the main loop logic.

### Updates to `builtin_exit` functionality:

* Enhanced the `builtin_exit` function to handle arguments, allowing the user to specify an exit status code. If no argument is provided, the shell exits with a default status of `0`.
* Added error handling for cases where multiple arguments are passed to the `exit` command, displaying an error message using `ft_dprintf`.
* Included a TODO comment to address potential overflow issues with the exit status code in the future.

### Changes to `readline_loop` logic:

* Removed the special case for handling the `exit` command directly in the `readline_loop` function. This logic is now fully delegated to the `builtin_exit` function for centralized handling.