### PR TITLE
fix: improve exit status handling and free allocated tokens in readli…

### DIFF
--- a/src/readline_loop.c
+++ b/src/readline_loop.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/28 19:02:03 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/02 19:34:54 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/03 16:19:42 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -61,6 +61,7 @@ void	readline_loop(t_shell *sh)
 			{
 				// print_tokens(tokens);
 				cmd = parse_tokens(tokens, sh);
+				free_tokens(tokens);
 				if (cmd && is_directory(cmd->args[0]))
 				{
 					sh->last_status = 126;
@@ -72,7 +73,6 @@ void	readline_loop(t_shell *sh)
 					// print_cmds(cmd);
 					executor(cmd, sh);
 				}
-				free_tokens(tokens);
 			}
 		}
 		free(input);


### PR DESCRIPTION
This pull request introduces improvements to process management and memory handling in the shell's execution and readline loop functionality. The key changes involve refining the handling of child process exit statuses and ensuring proper cleanup of allocated memory.

### Process Management Updates:
* Replaced `wait(NULL)` with `waitpid(-1, &status, 0)` in `execute_cmds` to handle child process statuses more accurately. Added logic to set `sh->last_status` based on exit codes or termination signals, including special handling for `SIGQUIT` and `SIGINT` signals. (`src/executor/executor.c`, [src/executor/executor.cL43-R56](diffhunk://#diff-a55a4faa58d161ee67291f2f04bfb06c03009af38cabdeeb1510eef95cdf159cL43-R56))

### Memory Management Improvements:
* Moved `free_tokens(tokens)` to immediately after `parse_tokens` in `readline_loop` to ensure tokens are freed as soon as they are no longer needed, reducing the risk of memory leaks. Removed the duplicate `free_tokens(tokens)` call later in the function. (`src/readline_loop.c`, [[1]](diffhunk://#diff-3c638e877f20879eafb4f7f8d7f548b03ff36391d3b5498288898bd67ac6ace6R64) [[2]](diffhunk://#diff-3c638e877f20879eafb4f7f8d7f548b03ff36391d3b5498288898bd67ac6ace6L75)