### PR TITLE
fix: update exit code handling for SIGINT and improve comments in exe…

### DIFF
--- a/src/executor/executor.c
+++ b/src/executor/executor.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/06 12:38:33 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/06/03 16:58:26 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/03 17:08:35 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <stdlib.h>
 
 void	execute_cmds(t_cmd *cmd, t_shell *sh)
 {
@@ -45,7 +46,7 @@ void	execute_cmds(t_cmd *cmd, t_shell *sh)
 		; // Wait for all child processes to finish
 	if (WIFEXITED(status))
 		sh->last_status = WEXITSTATUS(status);
-	//TODO: Wrong exit code for SIGQUIT and SIGINT
+	//TODO: Wrong exit code for SIGQUIT (CTRL +D)
 	if (WIFSIGNALED(status))
 	{
 		sh->last_status = WTERMSIG(status);


### PR DESCRIPTION
This pull request includes minor updates to the `src/executor/executor.c` file, focusing on code comments and the inclusion of a missing library. These changes improve code clarity and address a potential missing dependency.

### Code clarity improvements:
* Updated a TODO comment in the `execute_cmds` function to clarify that the wrong exit code issue applies specifically to `SIGQUIT` (CTRL+D).

### Dependency management:
* Added the `stdlib.h` library to ensure proper handling of standard library functions.