### PR TITLE
Chore/readline loop

### DIFF
--- a/src/readline_loop.c
+++ b/src/readline_loop.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/28 19:02:03 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/06 00:42:56 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/06 00:49:32 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -62,19 +62,18 @@ void	readline_loop(t_shell *sh)
 			tokens = lexer(input);
 			if (tokens)
 			{
-				// print_tokens(tokens);
 				cmd = parse_tokens(tokens, sh);
 				free_tokens(tokens);
 				if (cmd && is_directory(cmd->args[0]))
 					sh->last_status = 126;
 				else if (cmd)
 					executor(cmd, sh);
+				free_cmd_list(cmd);
 			}
 			else
 				sh->last_status = 2;
 		}
 		free(input);
 	}
-	// imitate Ctrl-D
 	write(1, "exit\n", 5);
 }

--- a/src/readline_loop.c
+++ b/src/readline_loop.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/28 19:02:03 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/05 23:32:38 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/06 00:42:56 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,7 +56,7 @@ void	readline_loop(t_shell *sh)
 			free(input);
 			continue ;
 		}
-		if (input[0] != '\0')
+		if (*input)
 		{
 			add_history(input);
 			tokens = lexer(input);
@@ -66,21 +66,12 @@ void	readline_loop(t_shell *sh)
 				cmd = parse_tokens(tokens, sh);
 				free_tokens(tokens);
 				if (cmd && is_directory(cmd->args[0]))
-				{
 					sh->last_status = 126;
-					free(input);
-					continue ;
-				}
-				if (cmd)
-				{
-					// print_cmds(cmd);
+				else if (cmd)
 					executor(cmd, sh);
-				}
 			}
 			else
-			{
 				sh->last_status = 2;
-			}
 		}
 		free(input);
 	}


### PR DESCRIPTION
This pull request makes updates to the `readline_loop.c` file, focusing on improving readability and simplifying logic within the `readline_loop` function. The changes include refactoring conditional checks, removing commented-out code, and adjusting the flow of execution.

### Refactoring and readability improvements:

* [`src/readline_loop.c`](diffhunk://#diff-3c638e877f20879eafb4f7f8d7f548b03ff36391d3b5498288898bd67ac6ace6L59-L87): Simplified the conditional check for non-empty input by replacing `input[0] != '* `src/readline_loop.c`: Simplified the conditional check for non-empty input by replacing `input[0] != '\0'` with `*input`, which is more concise and idiomatic. ([src/readline_loop.cL59-L87](diffhunk://#diff-3c638e877f20879eafb4f7f8d7f548b03ff36391d3b5498288898bd67ac6ace6L59-L87))'` with `*input`, which is more concise and idiomatic.

### Code cleanup and logic adjustments:

* [`src/readline_loop.c`](diffhunk://#diff-3c638e877f20879eafb4f7f8d7f548b03ff36391d3b5498288898bd67ac6ace6L59-L87): Removed commented-out debugging code (`print_tokens` and `print_cmds`) to clean up the function.
* [`src/readline_loop.c`](diffhunk://#diff-3c638e877f20879eafb4f7f8d7f548b03ff36391d3b5498288898bd67ac6ace6L59-L87): Adjusted the conditional logic for handling commands and directories, removing unnecessary code blocks and ensuring proper cleanup with `free_cmd_list(cmd)` after execution.

### Metadata update:

* [`src/readline_loop.c`](diffhunk://#diff-3c638e877f20879eafb4f7f8d7f548b03ff36391d3b5498288898bd67ac6ace6L9-R9): Updated the file metadata comment to reflect the new modification timestamp.