### PR TITLE
fix: Handle cd without options and arguments if HOME var is unset

### DIFF
--- a/src/builtin/builtin_cd.c
+++ b/src/builtin/builtin_cd.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/05 17:51:42 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/05/27 14:08:01 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/06 19:19:59 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,10 +34,18 @@ int	builtin_cd(t_cmd *cmd, t_env_list **env)
 	}
 	else if (cmd->args[1] == NULL)
 	{
-		chdir(find_node_by_key(env, "HOME")->value);
-		set_value(old_pwd, new_pwd->value);
-		set_value(new_pwd, getcwd(NULL, 0));
-		return (0);
+		if (find_node_by_key(env, "HOME"))
+		{
+			chdir(find_node_by_key(env, "HOME")->value);
+			set_value(old_pwd, new_pwd->value);
+			set_value(new_pwd, getcwd(NULL, 0));
+			return (0);
+		}
+		else
+		{
+			ft_putendl_fd("minishell: cd: HOME not set", 2);
+			return (1);
+		}
 	}
 	if (chdir(cmd->args[1]) == -1)
 	{


### PR DESCRIPTION
This pull request updates the `builtin_cd` function in `src/builtin/builtin_cd.c` to improve its handling of the `HOME` environment variable when no directory argument is provided. The changes ensure better error handling and user feedback when the `HOME` variable is not set.

### Improvements to `builtin_cd` function:

* Added a check to verify if the `HOME` environment variable exists before attempting to change the directory. If `HOME` is not set, an error message ("minishell: cd: HOME not set") is displayed, and the function returns with an error code. (`src/builtin/builtin_cd.c`, [src/builtin/builtin_cd.cR36-R49](diffhunk://#diff-062b84f2ee646135d82af1064e935afc4e237316e786b6c012092ecfe566b6b2R36-R49))

### Metadata update:

* Updated the file metadata to reflect the latest modification date. (`src/builtin/builtin_cd.c`, [src/builtin/builtin_cd.cL9-R9](diffhunk://#diff-062b84f2ee646135d82af1064e935afc4e237316e786b6c012092ecfe566b6b2L9-R9))