### PR TITLE
refactor: update init_sh function to return int for success/failure s…

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,16 +6,18 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/27 14:09:40 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/06/10 04:50:25 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/10 04:55:26 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef MINISHELL_H
 # define MINISHELL_H
 
-typedef struct s_env_list	t_env_list;
-
 # include <stdbool.h>
+# define SUCCESS 0
+# define FAILURE 1
+
+typedef struct s_env_list	t_env_list;
 
 // Main structure
 typedef struct s_shell
@@ -58,6 +60,6 @@ void						free_tokens(t_token *tokens);
 
 // readline_loop.c
 void						readline_loop(t_shell *sh);
-bool							is_directory(const char *path);
+bool						is_directory(const char *path);
 
 #endif

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/27 14:08:36 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/06/09 23:58:49 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/10 04:47:52 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,17 +16,19 @@
 #include "minishell.h"
 #include <stddef.h>
 #include <stdio.h>
+#include <stdlib.h>
 
-static t_shell	*init_sh(t_shell *sh, char **envp)
+static int	init_sh(t_shell *sh, char **envp)
 {
+	ft_memset(sh, 0, sizeof(sh));
 	sh->last_status = 0;
 	sh->env_list = lst_init(envp);
 	if (sh->env_list == NULL && *envp != NULL)
 	{
 		perror("minishell: init env");
-		return (NULL);
+		return (FAILURE);
 	}
-	return (sh);
+	return (SUCCESS);
 }
 
 int	main(int argc, char **argv, char **envp)
@@ -35,9 +37,8 @@ int	main(int argc, char **argv, char **envp)
 
 	(void)argc;
 	(void)argv;
-	ft_memset(&sh, 0, sizeof(sh));
-	if (init_sh(&sh, envp) == NULL)
-		return (1);
+	if (init_sh(&sh, envp) == FAILURE)
+		return (EXIT_FAILURE);
 	readline_loop(&sh);
 	lst_clear(&sh.env_list);
 	return (sh.last_status);


### PR DESCRIPTION
…tatus
This pull request introduces several changes to improve the initialization and error handling in the `minishell` project. The most significant updates include modifying the `init_sh` function to return status codes instead of a pointer, defining constants for success and failure, and updating the `main` function to handle initialization errors more robustly.

### Error handling improvements:

* [`include/minishell.h`](diffhunk://#diff-471850465338484d65e05947dade7a795e3e068ed9502a098e77c91b5ac1582fL9-R20): Added `SUCCESS` and `FAILURE` macros to standardize return codes for functions.
* [`src/minishell.c`](diffhunk://#diff-24d116499e6a7c6e447029d7af7c182d0e1663db9df63cf5ca065d3ef1426933R19-R31): Updated the `init_sh` function to return an `int` status code (`SUCCESS` or `FAILURE`) instead of a pointer, improving error handling and clarity.
* [`src/minishell.c`](diffhunk://#diff-24d116499e6a7c6e447029d7af7c182d0e1663db9df63cf5ca065d3ef1426933L38-R41): Modified the `main` function to check for `FAILURE` from `init_sh` and return `EXIT_FAILURE` instead of a hardcoded value, ensuring consistent error handling.

### Codebase cleanup:

* [`include/minishell.h`](diffhunk://#diff-471850465338484d65e05947dade7a795e3e068ed9502a098e77c91b5ac1582fL9-R20): Reordered the `t_env_list` typedef to align with other declarations and removed redundant code.
* [`src/minishell.c`](diffhunk://#diff-24d116499e6a7c6e447029d7af7c182d0e1663db9df63cf5ca065d3ef1426933R19-R31): Added the `<stdlib.h>` header for `EXIT_FAILURE` usage, ensuring compatibility and correctness.