### PR TITLE
fix: Change sizeof argument in ft_memset

### DIFF
--- a/src/minishell.c
+++ b/src/minishell.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
+/*   By: denissemenov <denissemenov@student.42.f    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/27 14:08:36 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/06/10 04:47:52 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/10 16:01:58 by denissemeno      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,7 @@
 
 static int	init_sh(t_shell *sh, char **envp)
 {
-	ft_memset(sh, 0, sizeof(sh));
+	ft_memset(sh, 0, sizeof(*sh));
 	sh->last_status = 0;
 	sh->env_list = lst_init(envp);
 	if (sh->env_list == NULL && *envp != NULL)


### PR DESCRIPTION
This pull request includes two changes to the `src/minishell.c` file. The first change updates the author information in the file header, and the second change fixes a bug in the `init_sh` function by correcting the `sizeof` argument.

Bug fix:

* [`src/minishell.c`](diffhunk://#diff-24d116499e6a7c6e447029d7af7c182d0e1663db9df63cf5ca065d3ef1426933L23-R23): Corrected the `sizeof` argument in the `ft_memset` call within the `init_sh` function from `sizeof(sh)` to `sizeof(*sh)` to ensure proper memory initialization.

Documentation update:

* [`src/minishell.c`](diffhunk://#diff-24d116499e6a7c6e447029d7af7c182d0e1663db9df63cf5ca065d3ef1426933L6-R9): Updated the author information in the file header to reflect the correct name and email address.