### PR TITLE
Restore main to b2e6e6d3 (snapshot rollback)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,11 @@ SRCS = minishell.c \
 		builtin/builtin_env.c \
 		builtin/builtin_exit.c \
 		builtin/builtin_utils.c \
+		executor/executor_child.c \
 		executor/executor.c \
-		executor/executor_utils.c \
 		executor/find_command.c \
+		executor/heredoc.c \
+		executor/redirection.c \
 		env/envp_list.c \
 		env/env_list_to_tab.c \
 		env/env_list_utils.c

--- a/include/executor.h
+++ b/include/executor.h
@@ -6,7 +6,7 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/06 12:39:30 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/06/10 11:10:05 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/06/11 14:47:12 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,11 +15,6 @@
 
 # include "parser.h"
 # include <sys/types.h>
-# define SUCCESS 0
-# define FAILURE 1
-# define CMD_NOT_FOUND 127
-# define CMD_IS_DIRECTORY 126
-# define HEREDOC_TMPFILE "minishell_heredoc"
 
 typedef struct s_pipe	t_pipe;
 
@@ -36,18 +31,20 @@ typedef struct s_pipe
 	};
 }						t_pipe;
 
-// find_command.c
-char					*find_command(char *cmd, char **envp);
-void					free_array(char **array);
+// executor_child.c
+pid_t					fork_and_execute_cmd(t_cmd *cmd, t_shell *sh,
+							int prev_fd, t_pipe pd);
 
 // executor.c
 void					executor(t_cmd *cmd, t_shell *sh);
-void					execute_cmds(t_cmd *cmd, t_shell *sh);
 
-// executor_utils.c
-pid_t					fork_and_execute_cmd(t_cmd *cmd, t_shell *sh,
-							int prev_fd, t_pipe pd);
-void					execute_child(t_cmd *cmd, t_shell *sh);
+// find_command.c
+char					*find_command(char *cmd, char **envp);
+
+// heredoc.c
+int						handle_heredoc(t_redir *redir, t_shell *sh);
+
+// redirection.c
 int						handle_redirections(t_cmd *cmd, t_shell *sh);
 
 // exit_utils.c

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
+/*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/27 14:09:40 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/06/11 01:42:32 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/11 14:46:20 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,6 +15,9 @@
 
 # define SUCCESS 0
 # define FAILURE 1
+# define CMD_NOT_FOUND 127
+# define CMD_IS_DIRECTORY 126
+# define HEREDOC_TMPFILE "minishell_heredoc"
 
 typedef struct s_env_list	t_env_list;
 

--- a/src/builtin/run_builtin.c
+++ b/src/builtin/run_builtin.c
@@ -6,7 +6,7 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/05 17:51:33 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/09 10:02:22 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/06/11 10:35:18 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,8 +28,8 @@ int	run_builtin(t_cmd *cmd, t_shell *sh)
 {
 	int								i;
 	static const t_builtins_array	builtins_arr[] = {{"echo", builtin_echo},
-			{"cd", builtin_cd}, {"pwd", builtin_pwd}, {"env", builtin_env},
-			{"export", builtin_export}, {"unset", builtin_unset}, {NULL, NULL}};
+	{"cd", builtin_cd}, {"pwd", builtin_pwd}, {"env", builtin_env},
+	{"export", builtin_export}, {"unset", builtin_unset}, {NULL, NULL}};
 
 	i = 0;
 	if (cmd == NULL || cmd->args == NULL || cmd->args[0] == NULL)

--- a/src/executor/executor.c
+++ b/src/executor/executor.c
@@ -3,27 +3,45 @@
 /*                                                        :::      ::::::::   */
 /*   executor.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
+/*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/06 12:38:33 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/06/11 01:48:11 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/11 14:52:27 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtins.h"
 #include "env.h"
 #include "executor.h"
-#include <stdlib.h>
-#include <sys/types.h>
-#include <sys/wait.h>
+#include "ft_printf.h"
 #include <signal.h>
-#include <unistd.h>
+#include <sys/wait.h>
 
-void	execute_cmds(t_cmd *cmd, t_shell *sh)
+static void	finalize_execution(pid_t last_pid, t_shell *sh)
+{
+	int	status;
+
+	signal(SIGINT, SIG_IGN);
+	waitpid(last_pid, &status, 0);
+	if (last_pid < 0)
+	{
+		lst_clear(&sh->env_list);
+		error_exit("fork");
+	}
+	if (WIFEXITED(status))
+		sh->last_status = WEXITSTATUS(status);
+	else if (WIFSIGNALED(status))
+		sh->last_status = 128 + WTERMSIG(status);
+	unlink(HEREDOC_TMPFILE);
+	while (wait(&status) > 0)
+		;
+}
+
+// Main function for executing commands in a pipeline
+static void	execute_cmds(t_cmd *cmd, t_shell *sh)
 {
 	t_pipe	pipefd;
 	int		prev_pipe_read_fd;
-	int		status;
 	pid_t	pid;
 
 	prev_pipe_read_fd = 0;
@@ -44,55 +62,48 @@ void	execute_cmds(t_cmd *cmd, t_shell *sh)
 		}
 		cmd = cmd->next;
 	}
-	signal(SIGINT, SIG_IGN);
-	waitpid(pid, &status, 0);
-	if (pid < 0)
-	{
-		lst_clear(&sh->env_list);
-		error_exit("fork");
-		return ;
-	}
-	if (WIFEXITED(status))
-		sh->last_status = WEXITSTATUS(status);
-	else if (WIFSIGNALED(status))
-		sh->last_status = 128 + WTERMSIG(status);
-	unlink(HEREDOC_TMPFILE);
-	while (wait(&status) > 0)
-		;
+	finalize_execution(pid, sh);
 }
 
-void	executor(t_cmd *cmd, t_shell *sh)
+// Function for a single command (without pipes)
+static void	run_single_command(t_cmd *cmd, t_shell *sh)
 {
 	int	saved_stdin;
 	int	saved_stdout;
 
-	sh->env_tab = env_list_to_tab(&sh->env_list);
-	// TODO: Handle NULL tab
-	// if (!sh->env_tab)
-	if (cmd->next == NULL)
+	saved_stdin = dup(STDIN_FILENO);
+	if (saved_stdin < 0)
+		error_exit("dup stdin");
+	saved_stdout = dup(STDOUT_FILENO);
+	if (saved_stdout < 0)
+		error_exit("dup stdout");
+	if (handle_redirections(cmd, sh) < 0)
 	{
-		// Single command with possible redirection
-		saved_stdin = dup(STDIN_FILENO);
-		// TODO: check -1 return for dup
-		saved_stdout = dup(STDOUT_FILENO);
-		if (handle_redirections(cmd,sh) < 0)
-		{
-			sh->last_status = 1;
-			free_env_tab(sh->env_tab);
-			return ;
-		}
-		// Run builtin (or fall back to external)
-		if (run_builtin(cmd, sh) == -1)
-			execute_cmds(cmd, sh);
-		// Restore original fds
-		dup2(saved_stdin, STDIN_FILENO);
-		dup2(saved_stdout, STDOUT_FILENO);
-		close(saved_stdin);
-		// TODO: check if closed
-		close(saved_stdout);
+		sh->last_status = 1;
+		free_env_tab(sh->env_tab);
+		return ;
 	}
+	if (run_builtin(cmd, sh) == -1)
+		execute_cmds(cmd, sh);
+	dup2(saved_stdin, STDIN_FILENO);
+	dup2(saved_stdout, STDOUT_FILENO);
+	close(saved_stdin);
+	close(saved_stdout);
+}
+
+void	executor(t_cmd *cmd, t_shell *sh)
+{
+	sh->env_tab = env_list_to_tab(&sh->env_list);
+	if (!sh->env_tab)
+	{
+		ft_dprintf(2, "minishell: env_list_to_tab failed\n");
+		sh->last_status = FAILURE;
+		return ;
+	}
+	if (cmd->next == NULL)
+		run_single_command(cmd, sh);
 	else
 		execute_cmds(cmd, sh);
-	// free_cmd_list(cmd); TODO: Fix double free crash (export TMP=HELLO)
+	free_cmd_list(cmd);
 	free_env_tab(sh->env_tab);
 }

--- a/src/executor/executor_child.c
+++ b/src/executor/executor_child.c
@@ -1,0 +1,97 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   executor_child.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/06/11 13:27:52 by tsargsya          #+#    #+#             */
+/*   Updated: 2025/06/11 14:49:56 by tsargsya         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "builtins.h"
+#include "executor.h"
+#include "libft.h"
+#include <signal.h>
+#include <stdlib.h>
+
+static void	execute_external_command(t_cmd *cmd, t_shell *sh)
+{
+	char	*cmd_name;
+	char	*full_cmd;
+
+	cmd_name = cmd->args[0];
+	if (cmd_name[0] == '\0')
+	{
+		write(2, "'': command not found\n", 23);
+		exit(CMD_NOT_FOUND);
+	}
+	full_cmd = find_command(cmd_name, sh->env_tab);
+	if (!full_cmd)
+	{
+		write(2, cmd_name, ft_strlen(cmd_name));
+		write(2, ": command not found\n", 21);
+		exit(CMD_NOT_FOUND);
+	}
+	if (is_directory(full_cmd))
+	{
+		free(full_cmd);
+		exit(CMD_IS_DIRECTORY);
+	}
+	execve(full_cmd, cmd->args, sh->env_tab);
+	free(full_cmd);
+	error_exit("execve");
+}
+
+static void	execute_child(t_cmd *cmd, t_shell *sh)
+{
+	if (handle_redirections(cmd, sh) < 0)
+	{
+		sh->last_status = 1;
+		exit(1);
+	}
+	if (!cmd->args || !cmd->args[0])
+		exit(0);
+	if (run_builtin(cmd, sh) == -1)
+		execute_external_command(cmd, sh);
+}
+
+static void	setup_child_fds(int prev_fd, t_pipe pd, t_cmd *cmd)
+{
+	int	dup2_ret;
+
+	if (prev_fd)
+	{
+		dup2_ret = dup2(prev_fd, STDIN_FILENO);
+		if (dup2_ret < 0)
+			error_exit("dup2");
+		close(prev_fd);
+	}
+	if (cmd->next)
+	{
+		close(pd.read);
+		dup2_ret = dup2(pd.write, STDOUT_FILENO);
+		if (dup2_ret < 0)
+			error_exit("dup2");
+		close(pd.write);
+	}
+}
+
+pid_t	fork_and_execute_cmd(t_cmd *cmd, t_shell *sh, int prev_fd, t_pipe pd)
+{
+	pid_t	pid;
+
+	pid = fork();
+	if (pid < 0)
+		error_exit("fork");
+	if (pid == 0)
+	{
+		signal(SIGINT, SIG_DFL);
+		signal(SIGQUIT, SIG_DFL);
+		setup_child_fds(prev_fd, pd, cmd);
+		execute_child(cmd, sh);
+		exit(0);
+	}
+	return (pid);
+}

--- a/src/executor/heredoc.c
+++ b/src/executor/heredoc.c
@@ -1,0 +1,113 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   heredoc.c                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/06/11 13:27:27 by tsargsya          #+#    #+#             */
+/*   Updated: 2025/06/11 14:54:17 by tsargsya         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "executor.h"
+#include "libft.h"
+#include <fcntl.h>
+#include <readline/readline.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+
+static int	process_heredoc_line(char *line, int fd, t_redir *redir,
+		t_shell *sh)
+{
+	char	*expanded;
+
+	if (ft_strcmp(line, redir->filename) == 0)
+	{
+		free(line);
+		return (0);
+	}
+	if (redir->quoted == 0)
+	{
+		expanded = expand_vars(line, sh);
+		if (expanded != NULL)
+			write(fd, expanded, ft_strlen(expanded));
+		free(expanded);
+	}
+	else
+	{
+		write(fd, line, ft_strlen(line));
+	}
+	write(fd, "\n", 1);
+	free(line);
+	return (1);
+}
+
+// Main function for writing heredoc
+static int	write_heredoc_content(t_redir *redir, t_shell *sh)
+{
+	int		fd;
+	char	*line;
+
+	fd = open(HEREDOC_TMPFILE, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+	if (fd < 0)
+	{
+		perror("open heredoc");
+		exit(1);
+	}
+	while (1)
+	{
+		line = readline("> ");
+		if (!line)
+			break ;
+		if (!process_heredoc_line(line, fd, redir, sh))
+			break ;
+	}
+	close(fd);
+	exit(0);
+}
+
+static int	wait_for_heredoc(pid_t pid, t_shell *sh)
+{
+	int	status;
+
+	waitpid(pid, &status, 0);
+	signal(SIGINT, sigint_handler);
+	if (WIFSIGNALED(status) && WTERMSIG(status) == SIGINT)
+	{
+		unlink(HEREDOC_TMPFILE);
+		sh->last_status = 130;
+		return (-1);
+	}
+	return (0);
+}
+
+int	handle_heredoc(t_redir *redir, t_shell *sh)
+{
+	pid_t	pid;
+
+	signal(SIGINT, SIG_IGN);
+	pid = fork();
+	if (pid == 0)
+	{
+		signal(SIGINT, SIG_DFL);
+		write_heredoc_content(redir, sh);
+	}
+	else if (pid > 0)
+	{
+		if (wait_for_heredoc(pid, sh) < 0)
+			return (-1);
+	}
+	else
+	{
+		perror("fork");
+		return (-1);
+	}
+	free(redir->filename);
+	redir->filename = ft_strdup(HEREDOC_TMPFILE);
+	if (!redir->filename)
+		return (-1);
+	redir->type = REDIR_IN;
+	return (0);
+}

--- a/src/executor/redirection.c
+++ b/src/executor/redirection.c
@@ -1,0 +1,84 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   redirection.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/06/11 13:27:40 by tsargsya          #+#    #+#             */
+/*   Updated: 2025/06/11 14:56:23 by tsargsya         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "executor.h"
+#include <fcntl.h>
+#include <readline/readline.h>
+#include <unistd.h>
+
+static int	open_redirection_file(t_redir *redir)
+{
+	int	fd;
+
+	if (redir->type == REDIR_IN)
+		fd = open(redir->filename, O_RDONLY);
+	else if (redir->type == REDIR_OUT)
+		fd = open(redir->filename, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	else if (redir->type == REDIR_APPEND)
+		fd = open(redir->filename, O_WRONLY | O_CREAT | O_APPEND, 0644);
+	if (fd < 0)
+		perror(redir->filename);
+	return (fd);
+}
+
+// Duplicates fd to stdin or stdout, closes it, and returns 0 or -1
+static int	redirect_fd_to_stdio(int fd, t_redir *redir)
+{
+	int	ret;
+
+	if (redir->type == REDIR_IN)
+		ret = dup2(fd, STDIN_FILENO);
+	else
+		ret = dup2(fd, STDOUT_FILENO);
+	if (ret < 0)
+	{
+		perror("dup2");
+		close(fd);
+		return (-1);
+	}
+	close(fd);
+	return (0);
+}
+
+// Applies a single redirection (including heredoc)
+static int	apply_one_redir(t_redir *redir, t_shell *sh)
+{
+	int	fd;
+
+	if (redir->type == REDIR_HEREDOC)
+		return (handle_heredoc(redir, sh));
+	fd = open_redirection_file(redir);
+	if (fd < 0)
+		return (-1);
+	return (redirect_fd_to_stdio(fd, redir));
+}
+
+int	handle_redirections(t_cmd *cmd, t_shell *sh)
+{
+	t_redir	*redir;
+
+	redir = cmd->in_redirs;
+	while (redir)
+	{
+		if (apply_one_redir(redir, sh) < 0)
+			return (-1);
+		redir = redir->next;
+	}
+	redir = cmd->out_redirs;
+	while (redir)
+	{
+		if (apply_one_redir(redir, sh) < 0)
+			return (-1);
+		redir = redir->next;
+	}
+	return (0);
+}


### PR DESCRIPTION
This pull request introduces significant updates to the `executor` subsystem of the `minishell` project. The changes include restructuring code for better modularity, adding new functionality for handling heredocs and redirections, and improving the execution of commands. Key updates involve new files, refactored functions, and enhanced error handling.

### Executor subsystem updates:

#### Modularization and new files:
* Added `executor_child.c`, which includes the `fork_and_execute_cmd` function for managing child processes and the `execute_external_command` function for running external commands. This modularization improves code clarity by separating child process logic from the main executor logic.
* Added `heredoc.c`, which implements the `handle_heredoc` function to manage heredoc redirections, including writing heredoc content and handling signals during heredoc processing.
* Added `redirection.c`, which provides the `handle_redirections` function for managing input/output redirections, including heredoc handling and file operations.

#### Refactoring for improved execution flow:
* Refactored `executor.c` to introduce helper functions like `finalize_execution` and `run_single_command`. These changes simplify the execution pipeline by separating single command execution from pipeline execution. [[1]](diffhunk://#diff-a55a4faa58d161ee67291f2f04bfb06c03009af38cabdeeb1510eef95cdf159cL6-L26) [[2]](diffhunk://#diff-a55a4faa58d161ee67291f2f04bfb06c03009af38cabdeeb1510eef95cdf159cL47-R107)

### Header file updates:

#### Consolidation of constants and declarations:
* Moved constants (`CMD_NOT_FOUND`, `CMD_IS_DIRECTORY`, `HEREDOC_TMPFILE`) from `executor.h` to `minishell.h` for better organization and accessibility across the project. [[1]](diffhunk://#diff-ebeeb1fe20145bf0170ddb0dec8614a326c3861d14571e10e490aec2bc6752c5L18-L22) [[2]](diffhunk://#diff-471850465338484d65e05947dade7a795e3e068ed9502a098e77c91b5ac1582fR18-R20)
* Updated function declarations in `executor.h` to reflect the new modular structure, removing obsolete functions and adding new ones for `executor_child.c`, `heredoc.c`, and `redirection.c`.

### Build system updates:

* Updated `Makefile` to include new source files (`executor_child.c`, `heredoc.c`, `redirection.c`) and remove obsolete ones (`executor_utils.c`). This ensures the new modular structure is reflected in the build process.