### PR TITLE
refactor: improve builtin_cd function and update environment variable…

### DIFF
--- a/src/builtin/builtin_cd.c
+++ b/src/builtin/builtin_cd.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/05 17:51:42 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/11 05:49:05 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/12 02:39:43 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,7 +18,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-static int	update_env_var(t_env_list **env, const char *key, char *value)
+static int	update_var(t_env_list **env, char *key, char *value)
 {
 	t_env_list	*node;
 
@@ -26,58 +26,99 @@ static int	update_env_var(t_env_list **env, const char *key, char *value)
 	if (node)
 	{
 		if (!set_value(node, value))
-		{
-			free(value);
-			perror("minishell");
 			return (1);
-		}
-		free(value);
 	}
 	else
 	{
-		if (export_argument(ft_strdup(key), value, env, EXPORT) != 0)
+		if (export_argument(ft_strdup(key), ft_strdup(value), env, EXPORT))
+			return (1);
+	}
+	return (0);
+}
+
+static int	update_pwd_pair(t_env_list **env, char *old, char *new)
+{
+	if (update_var(env, "OLDPWD", old))
+		return (1);
+	if (update_var(env, "PWD", new))
+		return (1);
+	return (0);
+}
+
+static int	get_target_path(t_cmd *cmd, t_env_list **env, char **dst)
+{
+	t_env_list	*home;
+
+	if (cmd->args[1] == NULL)
+	{
+		home = find_node_by_key(env, "HOME");
+		if (!home || !home->value)
 		{
-			free(value);
+			ft_putendl_fd("minishell: cd: HOME not set", 2);
 			return (1);
 		}
+		*dst = ft_strdup(home->value);
+	}
+	else if (cmd->args[2] != NULL)
+	{
+		ft_putendl_fd("minishell: cd: Too many arguments", 2);
+		return (1);
+	}
+	else
+		*dst = ft_strdup(cmd->args[1]);
+	if (!*dst)
+	{
+		perror("minishell");
+		return (1);
+	}
+	return (0);
+}
+
+static int	perform_cd(char *target, char **old_pwd, char **new_pwd)
+{
+	*old_pwd = getcwd(NULL, 0);
+	if (!*old_pwd)
+	{
+		perror("minishell");
+		return (1);
+	}
+	if (chdir(target) == -1)
+	{
+		perror("minishell");
+		free(*old_pwd);
+		return (1);
+	}
+	*new_pwd = getcwd(NULL, 0);
+	if (!*new_pwd)
+	{
+		perror("minishell");
+		free(*old_pwd);
+		return (1);
 	}
 	return (0);
 }
 
 int	builtin_cd(t_cmd *cmd, t_env_list **env)
 {
-	char		*old_pwd;
-	char		*new_pwd;
-	char		*target;
-	t_env_list	*home_node;
+	char	*target;
+	char	*old_pwd;
+	char	*new_pwd;
 
-	old_pwd = getcwd(NULL, 0);
-	if (!old_pwd)
-		return (perror("minishell"), 1);
-	if (cmd->args[1] == NULL)
+	if (get_target_path(cmd, env, &target))
+		return (1);
+	if (perform_cd(target, &old_pwd, &new_pwd))
 	{
-		home_node = find_node_by_key(env, "HOME");
-		if (!home_node || !home_node->value)
-			return (free(old_pwd), ft_putendl_fd("minishell: cd: HOME not set",
-					2), 1);
-		target = ft_strdup(home_node->value);
+		free(target);
+		return (1);
 	}
-	else if (cmd->args[2] != NULL)
-		return (free(old_pwd),
-			ft_putendl_fd("minishell: cd: Too many arguments", 2), 1);
-	else
-		target = ft_strdup(cmd->args[1]);
-	if (!target)
-		return (free(old_pwd), perror("minishell"), 1);
-	if (chdir(target) < 0)
-		return (perror("minishell"), free(old_pwd), free(target), 1);
 	free(target);
-	new_pwd = getcwd(NULL, 0);
-	if (!new_pwd)
-		return (perror("minishell"), free(old_pwd), 1);
-	if (update_env_var(env, "OLDPWD", old_pwd))
+	if (update_pwd_pair(env, old_pwd, new_pwd))
+	{
+		free(old_pwd);
+		free(new_pwd);
 		return (1);
-	if (update_env_var(env, "PWD", new_pwd))
-		return (1);
+	}
+	free(old_pwd);
+	free(new_pwd);
 	return (0);
 }


### PR DESCRIPTION
This pull request refactors the `builtin_cd` function in `src/builtin/builtin_cd.c` to improve readability, modularity, and error handling. The changes include splitting the logic into smaller helper functions, enhancing error messages, and simplifying the main `builtin_cd` function.

### Refactoring and Modularity Improvements:
* **Helper function `update_var`**: Refactored the `update_env_var` function into `update_var` to improve clarity and handle both updating existing environment variables and exporting new ones.
* **New helper function `update_pwd_pair`**: Added a function to update both `PWD` and `OLDPWD` environment variables, reducing redundancy in the main logic.
* **New helper function `get_target_path`**: Encapsulated logic for determining the target path into a dedicated function, improving readability and handling edge cases like missing `HOME` or too many arguments.
* **New helper function `perform_cd`**: Abstracted the `chdir` operation and related error handling into a separate function for better modularity and error management.

### Error Handling Enhancements:
* Improved error messages for scenarios like missing `HOME`, too many arguments, memory allocation failures, and failed directory changes.