### PR TITLE
refactor: add safe_strdup_pair function for key-value duplication

### DIFF
--- a/include/builtins.h
+++ b/include/builtins.h
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/30 15:11:19 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/07 22:11:34 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/12 02:46:41 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,5 +48,6 @@ void						free_key_value(char *key, char *value);
 t_export_type				is_valid_export(char *arg);
 int							export_argument(char *key, char *value,
 								t_env_list **env, t_export_type type);
-
+int							safe_strdup_pair(char *key, char *value,
+								char **output_key, char **output_value);
 #endif

--- a/src/builtin/builtin_cd.c
+++ b/src/builtin/builtin_cd.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/05 17:51:42 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/12 02:39:43 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/12 02:45:51 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,17 +21,19 @@
 static int	update_var(t_env_list **env, char *key, char *value)
 {
 	t_env_list	*node;
+	char		*temp_key;
+	char		*temp_value;
 
-	node = find_node_by_key(env, (char *)key);
+	node = find_node_by_key(env, key);
 	if (node)
+		return (!set_value(node, value));
+	if (safe_strdup_pair(key, value, &temp_key, &temp_value))
+		return (1);
+	if (export_argument(temp_key, temp_value, env, EXPORT))
 	{
-		if (!set_value(node, value))
-			return (1);
-	}
-	else
-	{
-		if (export_argument(ft_strdup(key), ft_strdup(value), env, EXPORT))
-			return (1);
+		free(temp_key);
+		free(temp_value);
+		return (1);
 	}
 	return (0);
 }

--- a/src/builtin/builtin_utils.c
+++ b/src/builtin/builtin_utils.c
@@ -6,12 +6,13 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/27 18:52:06 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/07 21:07:23 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/12 02:46:35 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtins.h"
 #include "libft.h"
+#include <stdio.h>
 #include <stdlib.h>
 
 void	free_key_value(char *key, char *value)
@@ -38,4 +39,20 @@ t_export_type	is_valid_export(char *arg)
 		arg++;
 	}
 	return (EXPORT);
+}
+
+int	safe_strdup_pair(char *key, char *value, char **output_key,
+		char **output_value)
+{
+	*output_key = ft_strdup(key);
+	if (!*output_key)
+		return (perror("minishell"), 1);
+	*output_value = ft_strdup(value);
+	if (!*output_value)
+	{
+		free(*output_key);
+		perror("minishell");
+		return (1);
+	}
+	return (0);
 }


### PR DESCRIPTION
This pull request introduces a new utility function, `safe_strdup_pair`, to improve memory management and error handling in key-value operations. The function is integrated into the `update_var` logic in `builtin_cd.c` to streamline duplication and cleanup processes. Additionally, minor updates were made to file headers and include statements.

### Memory management and error handling improvements:
* **New utility function `safe_strdup_pair`:** Added to safely duplicate key-value pairs with error handling. This function returns an error code and ensures cleanup of allocated memory in case of failure. (`src/builtin/builtin_utils.c`, [src/builtin/builtin_utils.cR43-R58](diffhunk://#diff-db9118fdc79372c6d8cd94834b09180a9f79d2b915843e6335362161b53ca8caR43-R58))
* **Integration of `safe_strdup_pair` in `update_var`:** Modified the `update_var` function in `builtin_cd.c` to use `safe_strdup_pair` for safer key-value duplication and cleanup. (`src/builtin/builtin_cd.c`, [src/builtin/builtin_cd.cR24-R35](diffhunk://#diff-062b84f2ee646135d82af1064e935afc4e237316e786b6c012092ecfe566b6b2R24-R35))

### Minor updates:
* **Function declaration for `safe_strdup_pair`:** Added to `include/builtins.h` for external usage. (`include/builtins.h`, [include/builtins.hL51-R52](diffhunk://#diff-b22e6a292fb34569b03da07796db81797934eaa4d16b02ef7f9fbe1ecdb08d72L51-R52))
* **Include statement update:** Added `<stdio.h>` to `builtin_utils.c` for `perror` usage. (`src/builtin/builtin_utils.c`, [src/builtin/builtin_utils.cL9-R15](diffhunk://#diff-db9118fdc79372c6d8cd94834b09180a9f79d2b915843e6335362161b53ca8caL9-R15))
* **Header timestamp updates:** Updated timestamps in file headers to reflect the latest changes. (`include/builtins.h`, [[1]](diffhunk://#diff-b22e6a292fb34569b03da07796db81797934eaa4d16b02ef7f9fbe1ecdb08d72L9-R9); `src/builtin/builtin_cd.c`, [[2]](diffhunk://#diff-062b84f2ee646135d82af1064e935afc4e237316e786b6c012092ecfe566b6b2L9-R9); `src/builtin/builtin_utils.c`, [[3]](diffhunk://#diff-db9118fdc79372c6d8cd94834b09180a9f79d2b915843e6335362161b53ca8caL9-R15)