### PR TITLE
refactor: improve error handling and code clarity in builtin commands

### DIFF
--- a/src/builtin/builtin_echo.c
+++ b/src/builtin/builtin_echo.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/29 18:02:24 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/10 05:21:11 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/12 05:11:56 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,8 +32,6 @@ static int	is_arg_n(const char *arg)
 
 static void	print_args(char **argv)
 {
-	if (*argv == NULL)
-		printf("\n");
 	while (*argv != NULL)
 	{
 		if (**argv == '\0')
@@ -65,12 +63,10 @@ int	builtin_echo(t_cmd *cmd, t_env_list **env)
 	{
 		if (has_n_arg == 0)
 			printf("\n");
-		// TODO: check security
 		return (0);
 	}
 	print_args(argv);
 	if (has_n_arg == 0)
 		printf("\n");
-	// TODO: check security
 	return (0);
 }

--- a/src/builtin/builtin_env.c
+++ b/src/builtin/builtin_env.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/05 17:51:59 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/05/18 15:07:23 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/12 04:12:03 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,19 +22,17 @@ int	builtin_env(t_cmd *cmd, t_env_list **env)
 {
 	t_env_list	*tmp;
 
-	if (env == NULL || *env == NULL)
-		return (2);
 	if (cmd->args[1])
 	{
-		ft_putendl_fd("env: Env doesn't take any arguments or options",
-			STDERR_FILENO);
+		ft_putendl_fd("env: too many arguments", STDERR_FILENO);
 		return (1);
 	}
+	if (env == NULL || *env == NULL)
+		return (0);
 	tmp = *env;
 	while (tmp)
 	{
 		printf("%s=%s\n", tmp->key, tmp->value);
-		//TODO: security check
 		tmp = tmp->next;
 	}
 	return (0);

--- a/src/builtin/builtin_exit.c
+++ b/src/builtin/builtin_exit.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/07 22:02:56 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/08 03:09:54 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/12 05:01:54 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,7 +25,7 @@ int	is_valid_numeric(char *arg)
 {
 	if (!(*arg))
 		return (0);
-	if (*arg == '-' && ft_isdigit(arg[1]))
+	if ((*arg == '-' || *arg == '+') && ft_isdigit(arg[1]))
 		arg++;
 	if (ft_strlen(arg) > 18)
 		return (0);
@@ -42,25 +42,25 @@ int	builtin_exit(t_shell *sh, char **argv)
 {
 	ft_dprintf(2, "exit\n");
 	if (argv[1] == NULL)
-		return (free_all_env(sh), 1);
-	else
 	{
-		if (!is_valid_numeric(argv[1]))
-		{
-			sh->last_status = 2;
-			ft_dprintf(2, "minishell: exit: %s: numeric argument required\n",
-				argv[1]);
-			free_all_env(sh);
-			return (1);
-		}
-		if (argv[2])
-		{
-			sh->last_status = 1;
-			ft_dprintf(2, "minishell: exit: too many arguments\n");
-			return (0);
-		}
-		sh->last_status = ft_atoi(argv[1]) % 256;
 		free_all_env(sh);
 		return (1);
 	}
+	if (!is_valid_numeric(argv[1]))
+	{
+		sh->last_status = 2;
+		ft_dprintf(2, "minishell: exit: %s: numeric argument required\n",
+			argv[1]);
+		free_all_env(sh);
+		return (1);
+	}
+	if (argv[2])
+	{
+		sh->last_status = 1;
+		ft_dprintf(2, "minishell: exit: too many arguments\n");
+		return (0);
+	}
+	sh->last_status = ft_atoi(argv[1]) % 256;
+	free_all_env(sh);
+	return (1);
 }

--- a/src/builtin/builtin_unset.c
+++ b/src/builtin/builtin_unset.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/05 17:52:38 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/10 05:26:54 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/12 04:38:48 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,14 +16,14 @@
 #include "parser.h"
 #include <stdlib.h>
 
-int	remove_var(char *argv, t_env_list **env)
+int	remove_var(char *name, t_env_list **env)
 {
 	t_env_list	*cur;
 	t_env_list	*prev;
 
 	cur = *env;
 	prev = NULL;
-	while (cur && ft_strcmp(cur->key, argv) != 0)
+	while (cur && ft_strcmp(cur->key, name) != 0)
 	{
 		prev = cur;
 		cur = cur->next;
@@ -47,10 +47,10 @@ int	builtin_unset(t_cmd *cmd, t_env_list **env)
 	char	**argv;
 
 	argv = &cmd->args[1];
-	if (argv == NULL)
+	if (*argv == NULL)
 		return (0);
 	if (env == NULL || *env == NULL)
-		return (1);
+		return (0);
 	while (*argv)
 	{
 		remove_var(*argv, env);


### PR DESCRIPTION
This pull request includes updates and fixes across several built-in shell commands (`echo`, `env`, `exit`, and `unset`) to improve functionality, fix logic issues, and enhance code readability. The most important changes include adjustments to argument handling, removal of outdated comments, and minor refactoring for clarity.

### Updates to argument handling:

* **`builtin_env`**: Updated error message for invalid arguments from "Env doesn't take any arguments or options" to "env: too many arguments" for better clarity. Also reordered the `env` null check for improved logic flow.
* **`builtin_exit`**: Enhanced numeric validation to allow both '+' and '-' signs in arguments. Simplified the logic for handling the absence of arguments by combining `free_all_env` and the return statement. [[1]](diffhunk://#diff-cda24ba56ddd5f277a95b631f71b80cff5a9aece06d4f1bc3fe121f456ef7413L28-R28) [[2]](diffhunk://#diff-cda24ba56ddd5f277a95b631f71b80cff5a9aece06d4f1bc3fe121f456ef7413L45-R48)

### Code cleanup and refactoring:

* **`builtin_echo`**: Removed outdated "TODO: check security" comments to clean up the code and improve readability.
* **`builtin_unset`**: Renamed the parameter `argv` to `name` in `remove_var` for better semantic clarity. Adjusted null checks to simplify logic when no arguments or environment variables are provided. [[1]](diffhunk://#diff-404d839bec3093dc1b0ffcdf4cfb03f05a2e087d7e102f593d5a86888cbdab32L19-R26) [[2]](diffhunk://#diff-404d839bec3093dc1b0ffcdf4cfb03f05a2e087d7e102f593d5a86888cbdab32L50-R53)