### PR TITLE
refactor: remove unnecessary includes in builtin_echo.c

### DIFF
--- a/src/builtin/builtin_echo.c
+++ b/src/builtin/builtin_echo.c
@@ -6,12 +6,10 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/29 18:02:24 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/12 05:11:56 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/12 05:16:47 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "builtins.h"
-#include "env.h"
 #include "parser.h"
 #include <stdio.h>
 


### PR DESCRIPTION
This pull request makes a minor update to the `src/builtin/builtin_echo.c` file. It removes the inclusion of `builtins.h` and `env.h` headers, leaving only the inclusion of `parser.h` and `<stdio.h>`. Additionally, the `Updated` timestamp in the file header comment has been modified.