### PR TITLE
Fix: Add free in exit. Move free_env_tab in executor, where it is mal…

### DIFF
--- a/src/builtin/run_builtin.c
+++ b/src/builtin/run_builtin.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   run_builtin.c                                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
+/*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/05 17:51:33 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/12 20:02:40 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/06/13 23:32:48 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,7 @@ static int	handle_exit(t_shell *sh, t_cmd *cmd)
 {
 	if (builtin_exit(sh, cmd->args) == 1)
 	{
+		free_cmd_list(cmd);
 		exit(sh->last_status);
 	}
 	else

--- a/src/executor/executor.c
+++ b/src/executor/executor.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   executor.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
+/*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/06 12:38:33 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/06/13 13:35:27 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/06/13 23:34:10 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -102,4 +102,5 @@ void	executor(t_cmd *cmd, t_shell *sh)
 		run_single_command(cmd, sh);
 	else
 		execute_cmds(cmd, sh);
+	free_env_tab(sh->env_tab);
 }

--- a/src/readline_loop.c
+++ b/src/readline_loop.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   readline_loop.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
+/*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/28 19:02:03 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/13 13:38:21 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/06/13 23:34:03 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -84,7 +84,6 @@ static void	process_input_line(char *input, t_shell *sh)
 	else
 		executor(cmd, sh);
 	free_cmd_list(cmd);
-	free_env_tab(sh->env_tab);
 }
 
 void	readline_loop(t_shell *sh)


### PR DESCRIPTION
This pull request introduces updates to improve memory management and code ownership annotations across several files. The most notable changes include adding proper cleanup functions to prevent memory leaks during command execution and modifying file headers to reflect updated ownership information.

### Memory Management Improvements:
* [`src/builtin/run_builtin.c`](diffhunk://#diff-829cf3d96ad51a4bf4dfd93cc288931eced59d558423d74b1b0ed9e5b9b7f7ecR25): Added a call to `free_cmd_list(cmd)` in the `handle_exit` function to ensure command resources are freed before exiting the shell.
* [`src/executor/executor.c`](diffhunk://#diff-a55a4faa58d161ee67291f2f04bfb06c03009af38cabdeeb1510eef95cdf159cR105): Added a call to `free_env_tab(sh->env_tab)` in the `executor` function to clean up the environment table after executing commands.
* [`src/readline_loop.c`](diffhunk://#diff-3c638e877f20879eafb4f7f8d7f548b03ff36391d3b5498288898bd67ac6ace6L87): Removed the redundant call to `free_env_tab(sh->env_tab)` in `process_input_line`, as this cleanup is now handled within the `executor` function.

### Code Ownership Updates:
* Updated file headers in `src/builtin/run_builtin.c`, `src/executor/executor.c`, and `src/readline_loop.c` to reflect ownership changes from `tsargsya` to `dsemenov`. [[1]](diffhunk://#diff-829cf3d96ad51a4bf4dfd93cc288931eced59d558423d74b1b0ed9e5b9b7f7ecL6-R9) [[2]](diffhunk://#diff-a55a4faa58d161ee67291f2f04bfb06c03009af38cabdeeb1510eef95cdf159cL6-R9) [[3]](diffhunk://#diff-3c638e877f20879eafb4f7f8d7f548b03ff36391d3b5498288898bd67ac6ace6L6-R9)