### PR TITLE
fix: Pass current node also to child process, so leaks of left nodes …

### DIFF
--- a/include/executor.h
+++ b/include/executor.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   executor.h                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
+/*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/06 12:39:30 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/06/11 14:47:12 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/06/14 00:17:57 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,7 +32,7 @@ typedef struct s_pipe
 }						t_pipe;
 
 // executor_child.c
-pid_t					fork_and_execute_cmd(t_cmd *cmd, t_shell *sh,
+pid_t					fork_and_execute_cmd(t_cmd *current, t_cmd *cmd, t_shell *sh,
 							int prev_fd, t_pipe pd);
 
 // executor.c

--- a/src/executor/executor.c
+++ b/src/executor/executor.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/06 12:38:33 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/06/13 23:34:10 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/14 00:20:27 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,7 +51,7 @@ static void	execute_cmds(t_cmd *cmd, t_shell *sh)
 		if (cur->next)
 			if (pipe(pipefd.fds) < 0)
 				error_exit("pipe");
-		last_pid = fork_and_execute_cmd(cur, sh, prev_fd, pipefd);
+		last_pid = fork_and_execute_cmd(cur, cmd, sh, prev_fd, pipefd);
 		if (prev_fd != 0)
 			close(prev_fd);
 		if (cur->next)

--- a/src/executor/executor_child.c
+++ b/src/executor/executor_child.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   executor_child.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
+/*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/11 13:27:52 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/06/13 14:18:03 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/06/14 00:29:04 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,6 +43,7 @@ static void	execute_external_command(t_cmd *cmd, t_shell *sh)
 		exit(CMD_IS_DIRECTORY);
 	}
 	execve(full_cmd, cmd->args, sh->env_tab);
+	//TODO: free env if execve fails?
 	free(full_cmd);
 	error_exit("execve");
 }
@@ -81,7 +82,7 @@ static void	setup_child_fds(int prev_fd, t_pipe pd, t_cmd *cmd)
 	}
 }
 
-pid_t	fork_and_execute_cmd(t_cmd *cmd, t_shell *sh, int prev_fd, t_pipe pd)
+pid_t	fork_and_execute_cmd(t_cmd *current_cmd, t_cmd *cmd, t_shell *sh, int prev_fd, t_pipe pd)
 {
 	pid_t	pid;
 
@@ -92,8 +93,8 @@ pid_t	fork_and_execute_cmd(t_cmd *cmd, t_shell *sh, int prev_fd, t_pipe pd)
 	{
 		signal(SIGINT, SIG_DFL);
 		signal(SIGQUIT, SIG_DFL);
-		setup_child_fds(prev_fd, pd, cmd);
-		execute_child(cmd, sh);
+		setup_child_fds(prev_fd, pd, current_cmd);
+		execute_child(current_cmd, sh);
 		free_cmd_list(cmd);
 		lst_clear(&sh->env_list);
 		free_env_tab(sh->env_tab);


### PR DESCRIPTION
This pull request refactors the `executor` module to improve code clarity and functionality. The key changes include adding a `current_cmd` parameter to better distinguish between the current and overall command contexts, updating comments for clarity, and introducing a TODO note for future error handling improvements.

### Refactoring for improved command handling:

* [`include/executor.h`](diffhunk://#diff-ebeeb1fe20145bf0170ddb0dec8614a326c3861d14571e10e490aec2bc6752c5L35-R35): Updated the `fork_and_execute_cmd` function signature to include a `current_cmd` parameter, distinguishing the current command from the overall command list.
* [`src/executor/executor.c`](diffhunk://#diff-a55a4faa58d161ee67291f2f04bfb06c03009af38cabdeeb1510eef95cdf159cL54-R54): Modified the call to `fork_and_execute_cmd` in `execute_cmds` to pass both `cur` (current command) and `cmd` (overall command list).
* [`src/executor/executor_child.c`](diffhunk://#diff-449ff6443c0b448a51584097a13c010a5d49a46d3787cd413fa0547100fa0ed3L84-R85): Updated the `fork_and_execute_cmd` function definition to use `current_cmd` and adjusted internal calls to `setup_child_fds` and `execute_child` accordingly. [[1]](diffhunk://#diff-449ff6443c0b448a51584097a13c010a5d49a46d3787cd413fa0547100fa0ed3L84-R85) [[2]](diffhunk://#diff-449ff6443c0b448a51584097a13c010a5d49a46d3787cd413fa0547100fa0ed3L95-R97)

### Documentation and comments:

* Updated file headers in `executor.h`, `executor.c`, and `executor_child.c` to reflect the new author and last modification timestamps. [[1]](diffhunk://#diff-ebeeb1fe20145bf0170ddb0dec8614a326c3861d14571e10e490aec2bc6752c5L6-R9) [[2]](diffhunk://#diff-a55a4faa58d161ee67291f2f04bfb06c03009af38cabdeeb1510eef95cdf159cL9-R9) [[3]](diffhunk://#diff-449ff6443c0b448a51584097a13c010a5d49a46d3787cd413fa0547100fa0ed3L6-R9)
* Added a TODO comment in `execute_external_command` to suggest freeing the environment if `execve` fails, highlighting a potential area for improvement.