### PR TITLE
fix: Clear history of commands after readline loop

### DIFF
--- a/src/readline_loop.c
+++ b/src/readline_loop.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/28 19:02:03 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/13 23:34:03 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/14 00:41:53 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -111,5 +111,6 @@ void	readline_loop(t_shell *sh)
 		free(input);
 		setup_signal_handlers();
 	}
+	clear_history();
 	write(1, "exit\n", 5);
 }


### PR DESCRIPTION
This pull request includes a minor update to the `readline_loop` function in `src/readline_loop.c`. The change ensures that the command history is cleared before exiting the program.

* [`src/readline_loop.c`](diffhunk://#diff-3c638e877f20879eafb4f7f8d7f548b03ff36391d3b5498288898bd67ac6ace6R114): Added a call to `clear_history()` in the `readline_loop` function to free up memory associated with the command history before exiting.