### PR TITLE
Refactor/export builtin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ SRCS = minishell.c \
 		builtin/builtin_cd.c \
 		builtin/builtin_pwd.c \
 		builtin/builtin_export.c \
+		builtin/export_utils.c \
 		builtin/builtin_unset.c \
 		builtin/builtin_env.c \
 		builtin/builtin_exit.c \

--- a/include/builtins.h
+++ b/include/builtins.h
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/30 15:11:19 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/12 02:46:41 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/17 00:31:10 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,6 +23,13 @@ typedef enum e_export_type
 	EXPORT,
 	CONCAT
 }							t_export_type;
+
+typedef struct s_export_data
+{
+	char					*key;
+	char					*value;
+	t_export_type			type;
+}							t_export_data;
 
 // Built-ins
 typedef int					(*t_builtin_func)(t_cmd *cmd, t_env_list **env);
@@ -44,10 +51,15 @@ int							builtin_exit(t_shell *sh, char **argv);
 int							run_builtin(t_cmd *cmd, t_shell *sh);
 
 // Utils
-void						free_key_value(char *key, char *value);
-t_export_type				is_valid_export(char *arg);
-int							export_argument(char *key, char *value,
-								t_env_list **env, t_export_type type);
+
 int							safe_strdup_pair(char *key, char *value,
 								char **output_key, char **output_value);
+
+// Export utils
+int							export_without_args(t_env_list **env);
+int							export_argument(char *key, char *value,
+								t_env_list **env, t_export_type type);
+void						free_key_value(char *key, char *value);
+t_export_type				is_valid_export(char *arg);
+
 #endif

--- a/include/builtins.h
+++ b/include/builtins.h
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/30 15:11:19 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/17 00:31:10 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/17 06:32:57 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@ typedef struct s_shell		t_shell;
 
 typedef enum e_export_type
 {
-	ERROR,
+	NONE,
 	EXPORT,
 	CONCAT
 }							t_export_type;
@@ -58,8 +58,12 @@ int							safe_strdup_pair(char *key, char *value,
 // Export utils
 int							export_without_args(t_env_list **env);
 int							export_argument(char *key, char *value,
-								t_env_list **env, t_export_type type);
+								t_env_list **env);
 void						free_key_value(char *key, char *value);
-t_export_type				is_valid_export(char *arg);
+void						free_export_data(t_export_data *data);
+t_export_type				is_valid_export(char *arg, t_export_data *data);
+int							parse_key_value(char *arg, t_export_data *data);
+int							create_new_var(char *key, char *value,
+								t_env_list **env);
 
 #endif

--- a/src/builtin/builtin_cd.c
+++ b/src/builtin/builtin_cd.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/05 17:51:42 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/12 03:09:23 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/17 02:21:46 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,7 +33,7 @@ static int	update_var(t_env_list **env, char *key, char *value)
 	}
 	if (safe_strdup_pair(key, value, &temp_key, &temp_value))
 		return (1);
-	if (export_argument(temp_key, temp_value, env, EXPORT))
+	if (export_argument(temp_key, temp_value, env))
 	{
 		free(temp_key);
 		free(temp_value);

--- a/src/builtin/builtin_export.c
+++ b/src/builtin/builtin_export.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/05 17:52:15 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/17 00:41:09 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/17 06:34:21 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,139 +19,86 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-int	parse_key_value(char *arg, char **key, char **value)
+int	concat_argument(char *key, char *value, t_env_list **env)
 {
-	char	*plus_sign;
-	char	*equality_sign;
-
-	plus_sign = ft_strchr(arg, '+');
-	equality_sign = ft_strchr(arg, '=');
-	if (plus_sign && (plus_sign + 1 == equality_sign))
-	{
-		*key = ft_substr(arg, 0, plus_sign - arg);
-		if (*key == NULL)
-		{
-			perror("minishell");
-			return (1);
-		}
-		*value = ft_strdup(++equality_sign);
-		if (*value == NULL)
-		{
-			perror("minishell");
-			free(*key);
-			return (1);
-		}
-	}
-	else
-	{
-		*key = ft_substr(arg, 0, equality_sign - arg);
-		if (*key == NULL)
-		{
-			perror("minishell");
-			return (1);
-		}
-		*value = ft_strdup(++equality_sign);
-		if (*value == NULL)
-		{
-			perror("minishell");
-			free(*key);
-			return (1);
-		}
-	}
-	return (0);
-}
-
-int	export_argument(char *key, char *value, t_env_list **env,
-		t_export_type type)
-{
-	t_env_list	*new_node;
-	t_env_list	*tmp_node;
+	t_env_list	*node;
 	char		*new_value;
 
-	if (!key || !value)
+	node = find_node_by_key(env, key);
+	if (node == NULL)
+		return (export_argument(key, value, env));
+	if (node->value != NULL)
+		new_value = ft_strjoin(node->value, value);
+	else
+		new_value = ft_strjoin("", value);
+	if (new_value == NULL)
 	{
-		free(key);
-		free(value);
+		perror("malloc");
 		return (1);
 	}
-	tmp_node = find_node_by_key(env, key);
-	if (tmp_node)
+	if (set_value(node, new_value) == NULL)
 	{
-		if (type == EXPORT)
-			set_value(tmp_node, value);
-		else if (type == CONCAT)
-		{
-			new_value = ft_strjoin(tmp_node->value, value);
-			if (!new_value)
-			{
-				perror("malloc");
-				free_key_value(key, value);
-				return (1);
-			}
-			if (!set_value(tmp_node, new_value))
-			{
-				free(new_value);
-				free_key_value(key, value);
-				return (1);
-			}
-			free(new_value);
-		}
-		free_key_value(key, value);
+		free(new_value);
+		return (1);
 	}
-	else
-	{
-		if ((new_node = lst_create_node(key, value)) == NULL)
-		{
-			perror("malloc");
-			free_key_value(key, value);
-			return (1);
-		}
-		lst_add_end(env, new_node);
-	}
-	return (0);
-}
-static int	export_or_concat(char *arg, t_export_data *data, t_env_list **env,
-		t_export_type type)
-{
-	if (ft_strchr(arg, '='))
-	{
-		if (parse_key_value(arg, &data->key, &data->value) == 1)
-			return (1);
-		if (export_argument(data->key, data->value, env, type) != 0)
-			return (1);
-	}
+	free(new_value);
 	return (0);
 }
 
-static int	handle_argument(char *arg, t_export_data *data, t_env_list **env)
+int	export_argument(char *key, char *value, t_env_list **env)
 {
-	t_export_type	type;
+	t_env_list	*node;
 
-	type = is_valid_export(arg);
-	if (type == ERROR)
+	node = find_node_by_key(env, key);
+	if (node != NULL)
+	{
+		if (set_value(node, value) == NULL)
+			return (1);
+		return (0);
+	}
+	return (create_new_var(key, value, env));
+}
+
+static int	export_or_concat(t_export_data *data, t_env_list **env)
+{
+	if (data->type == NONE)
+		return (0);
+	if (data->type == EXPORT)
+		return (export_argument(data->key, data->value, env));
+	return (concat_argument(data->key, data->value, env));
+}
+
+static int	handle_export_arg(char *arg, t_env_list **env)
+{
+	t_export_data	data;
+	int				err;
+
+	ft_memset(&data, 0, sizeof(data));
+	if (!is_valid_export(arg, &data))
 	{
 		ft_dprintf(2, "minishell: export: `%s': not a valid identifier\n", arg);
 		return (1);
 	}
-	else if (type == EXPORT || type == CONCAT)
-		export_or_concat(arg, data, env, type);
-	return (0);
+	err = parse_key_value(arg, &data);
+	if (err == 0)
+		err = export_or_concat(&data, env);
+	free_export_data(&data);
+	return (err);
 }
 
 int	builtin_export(t_cmd *cmd, t_env_list **env)
 {
-	t_export_data	data;
-	char			**argv;
-	int				ret;
+	char	**argv;
+	int		ret;
 
-	ft_memset(&data, 0, sizeof(data));
 	ret = 0;
 	if (cmd->args[1] == NULL)
 		return (export_without_args(env));
 	argv = &cmd->args[1];
-	while (*argv)
+	while (*argv != NULL)
 	{
-		ret = handle_argument(*argv, &data, env);
+		if (handle_export_arg(*argv, env))
+			ret = 1;
 		argv++;
 	}
 	return (ret);

--- a/src/builtin/builtin_utils.c
+++ b/src/builtin/builtin_utils.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/27 18:52:06 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/12 02:46:35 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/16 23:56:22 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,24 +21,6 @@ void	free_key_value(char *key, char *value)
 		free(key);
 	if (value)
 		free(value);
-}
-
-t_export_type	is_valid_export(char *arg)
-{
-	if ((ft_isalpha(arg[0]) != 1) && (arg[0] != '_'))
-		return (ERROR);
-	arg++;
-	while (*arg)
-	{
-		if ((*arg == '+') && (*(arg + 1) == '='))
-			return (CONCAT);
-		if (*arg == '=')
-			return (EXPORT);
-		if ((ft_isalnum(*arg) != 1) && (*arg != '_'))
-			return (ERROR);
-		arg++;
-	}
-	return (EXPORT);
 }
 
 int	safe_strdup_pair(char *key, char *value, char **output_key,

--- a/src/builtin/builtin_utils.c
+++ b/src/builtin/builtin_utils.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/27 18:52:06 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/16 23:56:22 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/17 03:22:14 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,6 +21,12 @@ void	free_key_value(char *key, char *value)
 		free(key);
 	if (value)
 		free(value);
+}
+
+void	free_export_data(t_export_data *data)
+{
+	free(data->key);
+	free(data->value);
 }
 
 int	safe_strdup_pair(char *key, char *value, char **output_key,

--- a/src/builtin/export_utils.c
+++ b/src/builtin/export_utils.c
@@ -1,0 +1,49 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   export_utils.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/06/16 23:44:05 by dsemenov          #+#    #+#             */
+/*   Updated: 2025/06/17 00:41:32 by dsemenov         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "builtins.h"
+#include "env.h"
+#include "libft.h"
+#include <stdio.h>
+
+int	export_without_args(t_env_list **env)
+{
+	t_env_list	*tmp;
+
+	if (env == NULL || *env == NULL)
+		return (1);
+	tmp = *env;
+	while (tmp)
+	{
+		printf("declare -x %s=%s\n", tmp->key, tmp->value);
+		tmp = tmp->next;
+	}
+	return (0);
+}
+
+t_export_type	is_valid_export(char *arg)
+{
+	if ((ft_isalpha(arg[0]) != 1) && (arg[0] != '_'))
+		return (ERROR);
+	arg++;
+	while (*arg)
+	{
+		if ((*arg == '+') && (*(arg + 1) == '='))
+			return (CONCAT);
+		if (*arg == '=')
+			return (EXPORT);
+		if ((ft_isalnum(*arg) != 1) && (*arg != '_'))
+			return (ERROR);
+		arg++;
+	}
+	return (EXPORT);
+}

--- a/src/builtin/export_utils.c
+++ b/src/builtin/export_utils.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/16 23:44:05 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/17 00:41:32 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/17 06:36:10 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,7 @@
 #include "env.h"
 #include "libft.h"
 #include <stdio.h>
+#include <stdlib.h>
 
 int	export_without_args(t_env_list **env)
 {
@@ -30,20 +31,83 @@ int	export_without_args(t_env_list **env)
 	return (0);
 }
 
-t_export_type	is_valid_export(char *arg)
+t_export_type	is_valid_export(char *arg, t_export_data *data)
 {
 	if ((ft_isalpha(arg[0]) != 1) && (arg[0] != '_'))
-		return (ERROR);
+		return (0);
 	arg++;
 	while (*arg)
 	{
 		if ((*arg == '+') && (*(arg + 1) == '='))
-			return (CONCAT);
+		{
+			data->type = CONCAT;
+			return (1);
+		}
 		if (*arg == '=')
-			return (EXPORT);
+		{
+			data->type = EXPORT;
+			return (1);
+		}
 		if ((ft_isalnum(*arg) != 1) && (*arg != '_'))
-			return (ERROR);
+			return (0);
 		arg++;
 	}
-	return (EXPORT);
+	data->type = NONE;
+	return (1);
+}
+
+int	parse_key_value(char *arg, t_export_data *data)
+{
+	char	*plus;
+	char	*equal;
+
+	plus = ft_strchr(arg, '+');
+	equal = ft_strchr(arg, '=');
+	if (equal == NULL)
+		return (0);
+	if (data->type == CONCAT)
+		data->key = ft_substr(arg, 0, plus - arg);
+	else
+		data->key = ft_substr(arg, 0, equal - arg);
+	if (data->key == NULL)
+	{
+		perror("minishell");
+		return (1);
+	}
+	equal++;
+	data->value = ft_strdup(equal);
+	if (data->value == NULL)
+	{
+		perror("minishell");
+		free(data->key);
+		return (1);
+	}
+	return (0);
+}
+
+int	create_new_var(char *key, char *value, t_env_list **env)
+{
+	char		*new_key;
+	char		*new_value;
+	t_env_list	*node;
+
+	new_key = ft_strdup(key);
+	new_value = ft_strdup(value);
+	if (new_key == NULL || new_value == NULL)
+	{
+		free(new_key);
+		free(new_value);
+		perror("minishell");
+		return (1);
+	}
+	node = lst_create_node(new_key, new_value);
+	if (node == NULL)
+	{
+		free(new_key);
+		free(new_value);
+		perror("minishell");
+		return (1);
+	}
+	lst_add_end(env, node);
+	return (0);
 }

--- a/src/executor/executor_child.c
+++ b/src/executor/executor_child.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   executor_child.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
+/*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/11 13:27:52 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/06/14 19:56:44 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/06/17 06:21:11 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -105,7 +105,7 @@ pid_t	fork_and_execute_cmd(t_cmd *current_cmd, t_shell *sh, int prev_fd,
 		setup_child_fds(prev_fd, pd, current_cmd);
 		execute_child(current_cmd, sh);
 		free_all_resources(sh);
-		exit(0);
+		exit(sh->last_status);
 	}
 	return (pid);
 }


### PR DESCRIPTION
This pull request introduces several enhancements and refactors to the built-in commands and utilities in the Minishell project. The changes focus on improving the handling of the `export` built-in command, simplifying code logic, and adding new utilities for better modularity. Additionally, it updates the child process exit behavior in the executor module.

### Built-in Command Enhancements:
* **Refactored `export` command logic**: Added a new `t_export_data` structure to encapsulate key-value pairs and export types. Refactored the `export_argument` function to simplify handling of concatenation and creation of new variables. Introduced helper functions like `handle_export_arg` and `export_or_concat` for modularity. [[1]](diffhunk://#diff-b22e6a292fb34569b03da07796db81797934eaa4d16b02ef7f9fbe1ecdb08d72L22-R33) [[2]](diffhunk://#diff-1d323fa3ae3bee94c06f2ddfaa91331f4a62f8ee2186857241822650247a06c9L22-L160)
* **Moved utility functions to `export_utils.c`**: Extracted common utility functions (`is_valid_export`, `parse_key_value`, `create_new_var`, etc.) into `src/builtin/export_utils.c` for better organization and reusability.

### Code Simplification:
* **Removed redundant parameters**: Simplified function signatures, such as removing the `type` parameter from `export_argument` and related functions. [[1]](diffhunk://#diff-062b84f2ee646135d82af1064e935afc4e237316e786b6c012092ecfe566b6b2L36-R36) [[2]](diffhunk://#diff-1d323fa3ae3bee94c06f2ddfaa91331f4a62f8ee2186857241822650247a06c9L22-L160)

### Modularization:
* **Updated `Makefile`**: Added `builtin/export_utils.c` to the source files list to include the newly created module.

### Executor Module Update:
* **Child process exit behavior**: Changed the `fork_and_execute_cmd` function to exit with the shell's last status instead of a fixed value, ensuring proper status propagation.

### Miscellaneous Updates:
* **Header file updates**: Updated the `builtins.h` header file to include new structures and function prototypes related to the refactored `export` command.
* **Updated author metadata**: Modified file headers to reflect the current author and update timestamps. [[1]](diffhunk://#diff-b22e6a292fb34569b03da07796db81797934eaa4d16b02ef7f9fbe1ecdb08d72L9-R9) [[2]](diffhunk://#diff-062b84f2ee646135d82af1064e935afc4e237316e786b6c012092ecfe566b6b2L9-R9) [[3]](diffhunk://#diff-1d323fa3ae3bee94c06f2ddfaa91331f4a62f8ee2186857241822650247a06c9L9-R9) [[4]](diffhunk://#diff-db9118fdc79372c6d8cd94834b09180a9f79d2b915843e6335362161b53ca8caL9-R9) [[5]](diffhunk://#diff-449ff6443c0b448a51584097a13c010a5d49a46d3787cd413fa0547100fa0ed3L6-R9)