### PR TITLE
Fix: Bug with cd if directory above is removed. Handle pwd if can't a…

### DIFF
--- a/include/builtins.h
+++ b/include/builtins.h
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/30 15:11:19 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/17 06:32:57 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/17 21:01:38 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,6 +54,7 @@ int							run_builtin(t_cmd *cmd, t_shell *sh);
 
 int							safe_strdup_pair(char *key, char *value,
 								char **output_key, char **output_value);
+void						free_pwds(char *old_pwd, char *new_pwd);
 
 // Export utils
 int							export_without_args(t_env_list **env);

--- a/src/builtin/builtin_cd.c
+++ b/src/builtin/builtin_cd.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/05 17:51:42 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/17 02:21:46 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/17 21:05:25 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,6 +23,7 @@ static int	update_var(t_env_list **env, char *key, char *value)
 	t_env_list	*node;
 	char		*temp_key;
 	char		*temp_value;
+	int			ret;
 
 	node = find_node_by_key(env, key);
 	if (node)
@@ -33,22 +34,10 @@ static int	update_var(t_env_list **env, char *key, char *value)
 	}
 	if (safe_strdup_pair(key, value, &temp_key, &temp_value))
 		return (1);
-	if (export_argument(temp_key, temp_value, env))
-	{
-		free(temp_key);
-		free(temp_value);
-		return (1);
-	}
-	return (0);
-}
-
-static int	update_pwd_pair(t_env_list **env, char *old, char *new)
-{
-	if (update_var(env, "OLDPWD", old))
-		return (1);
-	if (update_var(env, "PWD", new))
-		return (1);
-	return (0);
+	ret = export_argument(temp_key, temp_value, env);
+	free(temp_key);
+	free(temp_value);
+	return (ret);
 }
 
 static int	get_target_path(t_cmd *cmd, t_env_list **env, char **dst)
@@ -80,14 +69,25 @@ static int	get_target_path(t_cmd *cmd, t_env_list **env, char **dst)
 	return (0);
 }
 
-static int	perform_cd(char *target, char **old_pwd, char **new_pwd)
+static char	*safe_getcwd(t_env_list **env)
 {
-	*old_pwd = getcwd(NULL, 0);
-	if (!*old_pwd)
+	char		*cwd;
+	t_env_list	*pwd;
+
+	cwd = getcwd(NULL, 0);
+	if (!cwd)
 	{
-		perror("minishell");
-		return (1);
+		pwd = find_node_by_key(env, "PWD");
+		if (pwd && pwd->value)
+			cwd = ft_strdup(pwd->value);
 	}
+	return (cwd);
+}
+
+static int	perform_cd(char *target, char **old_pwd, char **new_pwd,
+		t_env_list **env)
+{
+	*old_pwd = safe_getcwd(env);
 	if (chdir(target) == -1)
 	{
 		perror("minishell");
@@ -95,6 +95,10 @@ static int	perform_cd(char *target, char **old_pwd, char **new_pwd)
 		return (1);
 	}
 	*new_pwd = getcwd(NULL, 0);
+	if (!*new_pwd)
+	{
+		*new_pwd = ft_strdup(target);
+	}
 	if (!*new_pwd)
 	{
 		perror("minishell");
@@ -112,19 +116,22 @@ int	builtin_cd(t_cmd *cmd, t_env_list **env)
 
 	if (get_target_path(cmd, env, &target))
 		return (1);
-	if (perform_cd(target, &old_pwd, &new_pwd))
+	if (perform_cd(target, &old_pwd, &new_pwd, env))
 	{
 		free(target);
 		return (1);
 	}
 	free(target);
-	if (update_pwd_pair(env, old_pwd, new_pwd))
+	if (old_pwd && update_var(env, "OLDPWD", old_pwd))
 	{
-		free(old_pwd);
-		free(new_pwd);
+		free_pwds(old_pwd, new_pwd);
 		return (1);
 	}
-	free(old_pwd);
-	free(new_pwd);
+	if (update_var(env, "PWD", new_pwd))
+	{
+		free_pwds(old_pwd, new_pwd);
+		return (1);
+	}
+	free_pwds(old_pwd, new_pwd);
 	return (0);
 }

--- a/src/builtin/builtin_pwd.c
+++ b/src/builtin/builtin_pwd.c
@@ -6,30 +6,41 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/05 17:52:23 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/11 02:13:04 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/17 21:26:54 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtins.h"
 #include "env.h"
+#include "ft_printf.h"
 #include "parser.h"
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 int	builtin_pwd(t_cmd *cmd, t_env_list **env)
 {
-	char	*cwd;
+	char		*cwd;
+	t_env_list	*pwd_node;
 
-	(void)env;
 	(void)cmd;
 	cwd = getcwd(NULL, 0);
-	if (cwd == NULL)
+	if (cwd)
 	{
-		perror("pwd");
-		return (EXIT_FAILURE);
+		printf("%s\n", cwd);
+		free(cwd);
+		return (EXIT_SUCCESS);
 	}
-	printf("%s\n", cwd);
-	free(cwd);
-	return (EXIT_SUCCESS);
+	pwd_node = find_node_by_key(env, "PWD");
+	if (pwd_node && pwd_node->value)
+	{
+		ft_dprintf(2, "pwd: warning: cannot access current directory: %s\n",
+			strerror(errno));
+		printf("%s\n", pwd_node->value);
+		return (EXIT_SUCCESS);
+	}
+	perror("pwd");
+	return (EXIT_FAILURE);
 }

--- a/src/builtin/builtin_utils.c
+++ b/src/builtin/builtin_utils.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/27 18:52:06 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/17 03:22:14 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/17 21:01:21 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,6 +21,14 @@ void	free_key_value(char *key, char *value)
 		free(key);
 	if (value)
 		free(value);
+}
+
+void	free_pwds(char *old_pwd, char *new_pwd)
+{
+	if (old_pwd)
+		free(old_pwd);
+	if (new_pwd)
+		free(new_pwd);
 }
 
 void	free_export_data(t_export_data *data)

--- a/src/env/env_list_utils.c
+++ b/src/env/env_list_utils.c
@@ -6,7 +6,7 @@
 /*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/27 14:07:38 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/12 03:48:19 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/17 21:12:58 by dsemenov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,8 +41,7 @@ t_env_list	*set_value(t_env_list *node, char *value)
 		perror("minishell");
 		return (NULL);
 	}
-	if (node->value != value)
-		free(node->value);
+	free(node->value);
 	node->value = dup;
 	return (node);
 }


### PR DESCRIPTION
This pull request introduces improvements and refactoring to the built-in commands in the shell, particularly focusing on the `cd`, `pwd`, and utility functions. The changes enhance error handling, streamline code, and improve memory management.

### Enhancements to built-in commands:

* **Improved error handling in `builtin_pwd`:** Added logic to handle inaccessible directories gracefully by falling back to the `PWD` environment variable. If neither the current directory nor `PWD` is accessible, an error message is displayed using `ft_dprintf`. (`[src/builtin/builtin_pwd.cL9-R46](diffhunk://#diff-ede4b0953b2f0d76796364d8f9976097f070376bda68f66a204514025f5aba86L9-R46)`)
* **Refactored `builtin_cd`:** Introduced `safe_getcwd` to retrieve the current working directory safely, even if `getcwd` fails. Updated `perform_cd` and `builtin_cd` to use this function and handle memory cleanup with the new `free_pwds` utility. (`[[1]](diffhunk://#diff-062b84f2ee646135d82af1064e935afc4e237316e786b6c012092ecfe566b6b2L83-R90)`, `[[2]](diffhunk://#diff-062b84f2ee646135d82af1064e935afc4e237316e786b6c012092ecfe566b6b2L115-R135)`)

### Memory management improvements:

* **Added `free_pwds` utility:** Created a helper function to free `old_pwd` and `new_pwd` pointers, ensuring consistent and safe memory deallocation across the codebase. (`[src/builtin/builtin_utils.cR26-R33](diffhunk://#diff-db9118fdc79372c6d8cd94834b09180a9f79d2b915843e6335362161b53ca8caR26-R33)`)
* **Simplified `update_var`:** Refactored the function to reduce redundancy and improve readability by using a single return value (`ret`) instead of nested conditions. (`[src/builtin/builtin_cd.cL36-R40](diffhunk://#diff-062b84f2ee646135d82af1064e935afc4e237316e786b6c012092ecfe566b6b2L36-R40)`)

### Code cleanup:

* **Removed redundant checks in `set_value`:** Eliminated unnecessary comparison of the `value` pointer to streamline the logic. (`[src/env/env_list_utils.cL44](diffhunk://#diff-e56ac795c3a189389f4c28d8a9c54ad2b550e6f45955182f0b2efa6c13fddecfL44)`)