### PR TITLE
Docs env

### DIFF
--- a/src/env/env_list_to_tab.c
+++ b/src/env/env_list_to_tab.c
@@ -6,7 +6,7 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/15 16:00:25 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/14 18:56:52 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/06/19 16:59:38 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+/**
+ * @brief Joins two strings with an '=' in between.
+ * Allocates memory for the new string and returns it.
+ * @param s1 The first string (key).
+ * @param s2 The second string (value).
+ * @return A new string containing "s1=s2", or NULL on failure.
+ */
 static char	*ft_strjoin3(char const *s1, char const *s2)
 {
 	size_t	total_len;
@@ -34,6 +41,12 @@ static char	*ft_strjoin3(char const *s1, char const *s2)
 	return (res);
 }
 
+/**
+ * @brief Returns an empty environment tab.
+ * Allocates memory for a single NULL pointer and returns it.
+ * @return A pointer to an array containing a single NULL pointer,
+ * or NULL on failure.
+ */
 static char	**return_empty_tab(void)
 {
 	char	**tab;
@@ -48,6 +61,13 @@ static char	**return_empty_tab(void)
 	return (tab);
 }
 
+/**
+ * @brief Fills the environment tab with key-value pairs from the list.
+ * @param list Pointer to the environment list.
+ * @param tab Pointer to the environment tab.
+ * @param len The number of elements to fill.
+ * @return A pointer to the filled environment tab, or NULL on failure.
+ */
 static char	**fill_tab(t_env_list **list, char **tab, size_t len)
 {
 	t_env_list	*tmp;
@@ -70,6 +90,16 @@ static char	**fill_tab(t_env_list **list, char **tab, size_t len)
 	return (tab);
 }
 
+/**
+ * @brief Converts an environment list to a tab of strings.
+ * This function iterates through the environment list,
+ * concatenates each key-value pair into a string of the form "key=value",
+ * and stores the result in a newly allocated array.
+ * @param env_list Pointer to the environment list.
+ * @return A pointer to an array of strings representing the environment,
+ * or NULL on failure. If the list is empty, returns an array with a single
+ * NULL pointer.
+ */
 char	**env_list_to_tab(t_env_list **env_list)
 {
 	char	**env_tab;

--- a/src/env/env_list_utils.c
+++ b/src/env/env_list_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   env_list_utils.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
+/*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/27 14:07:38 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/17 21:12:58 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/19 17:03:33 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,6 +15,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+/**
+ * @brief Finds a node in the environment list by its key.
+ * @param env Pointer to the environment list.
+ * @param key The key to search for.
+ * @return A pointer to the node with the matching key, or NULL if not found.
+ */
 t_env_list	*find_node_by_key(t_env_list **env, char *key)
 {
 	t_env_list	*tmp;
@@ -29,6 +35,12 @@ t_env_list	*find_node_by_key(t_env_list **env, char *key)
 	return (NULL);
 }
 
+/**
+ * @brief Sets the value of a node in the environment list.
+ * @param node The node to update.
+ * @param value The new value to set.
+ * @return A pointer to the updated node, or NULL on failure.
+ */
 t_env_list	*set_value(t_env_list *node, char *value)
 {
 	char	*dup;
@@ -46,6 +58,12 @@ t_env_list	*set_value(t_env_list *node, char *value)
 	return (node);
 }
 
+/**
+ * @brief Handles memory cleanups for failed entry additions.
+ * @param key The key to free, if allocated.
+ * @param value The value to free, if allocated.
+ * @return 1 to indicate failure.
+ */
 static int	entry_fail(char *key, char *value)
 {
 	if (key)
@@ -56,6 +74,12 @@ static int	entry_fail(char *key, char *value)
 	return (1);
 }
 
+/**
+ * @brief Adds a new entry to the environment list.
+ * @param entry The entry string in the format "key=value".
+ * @param list Pointer to the environment list.
+ * @return 0 on success, or 1 on failure.
+ */
 int	add_env_entry(char *entry, t_env_list **list)
 {
 	char		*equal_sign;

--- a/src/env/env_list_utils.c
+++ b/src/env/env_list_utils.c
@@ -6,7 +6,7 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/27 14:07:38 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/19 17:03:33 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/06/19 17:05:17 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,22 @@
 #include "libft.h"
 #include <stdio.h>
 #include <stdlib.h>
+
+/**
+ * @brief Handles memory cleanups for failed entry additions.
+ * @param key The key to free, if allocated.
+ * @param value The value to free, if allocated.
+ * @return 1 to indicate failure.
+ */
+static int	entry_fail(char *key, char *value)
+{
+	if (key)
+		free(key);
+	if (value)
+		free(value);
+	perror("minishell");
+	return (1);
+}
 
 /**
  * @brief Finds a node in the environment list by its key.
@@ -56,22 +72,6 @@ t_env_list	*set_value(t_env_list *node, char *value)
 	free(node->value);
 	node->value = dup;
 	return (node);
-}
-
-/**
- * @brief Handles memory cleanups for failed entry additions.
- * @param key The key to free, if allocated.
- * @param value The value to free, if allocated.
- * @return 1 to indicate failure.
- */
-static int	entry_fail(char *key, char *value)
-{
-	if (key)
-		free(key);
-	if (value)
-		free(value);
-	perror("minishell");
-	return (1);
 }
 
 /**

--- a/src/env/envp_list.c
+++ b/src/env/envp_list.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   envp_list.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: dsemenov <dsemenov@student.42.fr>          +#+  +:+       +#+        */
+/*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/30 15:16:40 by dsemenov          #+#    #+#             */
-/*   Updated: 2025/06/12 03:54:49 by dsemenov         ###   ########.fr       */
+/*   Updated: 2025/06/19 17:11:27 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,12 @@
 #include <stddef.h>
 #include <stdlib.h>
 
+/**
+ * @brief Creates a new environment list node with the given key and value.
+ * @param key The key of the environment variable.
+ * @param value The value of the environment variable.
+ * @return A pointer to the newly created node, or NULL on failure.
+ */
 t_env_list	*lst_create_node(char *key, char *value)
 {
 	t_env_list	*node;
@@ -29,6 +35,11 @@ t_env_list	*lst_create_node(char *key, char *value)
 	return (node);
 }
 
+/**
+ * @brief Adds a new environment node to the end of the list.
+ * @param list Pointer to the pointer of the environment list.
+ * @param new_node The new node to add to the list.
+ */
 void	lst_add_end(t_env_list **list, t_env_list *new_node)
 {
 	t_env_list	*tmp;
@@ -46,6 +57,11 @@ void	lst_add_end(t_env_list **list, t_env_list *new_node)
 	tmp->next = new_node;
 }
 
+/**
+ * @brief Initializes the environment list from the given envp array.
+ * @param envp The environment variables array.
+ * @return A pointer to the initialized environment list, or NULL on failure.
+ */
 t_env_list	*lst_init(char *const *envp)
 {
 	t_env_list	*list;
@@ -63,6 +79,10 @@ t_env_list	*lst_init(char *const *envp)
 	return (list);
 }
 
+/**
+ * @brief Clears the environment list and frees all allocated memory.
+ * @param list Pointer to the pointer of the environment list.
+ */
 void	lst_clear(t_env_list **list)
 {
 	t_env_list	*tmp;
@@ -81,6 +101,11 @@ void	lst_clear(t_env_list **list)
 	}
 }
 
+/**
+ * @brief Returns the size of the environment list.
+ * @param list Pointer to the pointer of the environment list.
+ * @return The number of nodes in the list, or 0 if the list is empty.
+ */
 size_t	lst_size(t_env_list **list)
 {
 	size_t		size;


### PR DESCRIPTION
This pull request focuses on improving code documentation across multiple files in the `src/env` directory by adding detailed comments for functions. These comments describe the purpose, parameters, and return values of the functions, improving code readability and maintainability. Additionally, there are minor updates to file metadata.

### Documentation Improvements:

**In `src/env/env_list_to_tab.c`:**
* Added detailed comments for the following functions:
  - [`ft_strjoin3`](diffhunk://#diff-f56fee0965d8eee1dc545d113f8c8391952395b68e4d4d92befe323ce3a67da7R19-R25): Explains the purpose of joining two strings with an '=' in between.
  - [`return_empty_tab`](diffhunk://#diff-f56fee0965d8eee1dc545d113f8c8391952395b68e4d4d92befe323ce3a67da7R44-R49): Describes how it returns an empty environment tab.
  - [`fill_tab`](diffhunk://#diff-f56fee0965d8eee1dc545d113f8c8391952395b68e4d4d92befe323ce3a67da7R64-R70): Details how it fills an environment tab with key-value pairs from a list.
  - [`env_list_to_tab`](diffhunk://#diff-f56fee0965d8eee1dc545d113f8c8391952395b68e4d4d92befe323ce3a67da7R93-R102): Explains the conversion of an environment list to a tab of strings.

**In `src/env/env_list_utils.c`:**
* Added comments for:
  - [`entry_fail`](diffhunk://#diff-e56ac795c3a189389f4c28d8a9c54ad2b550e6f45955182f0b2efa6c13fddecfR18-R39): Handles memory cleanup for failed entry additions.
  - [`find_node_by_key`](diffhunk://#diff-e56ac795c3a189389f4c28d8a9c54ad2b550e6f45955182f0b2efa6c13fddecfR18-R39): Finds a node in the environment list by its key.
  - [`set_value`](diffhunk://#diff-e56ac795c3a189389f4c28d8a9c54ad2b550e6f45955182f0b2efa6c13fddecfR54-R59): Updates the value of a node in the environment list.
  - [`add_env_entry`](diffhunk://#diff-e56ac795c3a189389f4c28d8a9c54ad2b550e6f45955182f0b2efa6c13fddecfL49-R82): Adds a new entry to the environment list.

**In `src/env/envp_list.c`:**
* Documented the following functions:
  - [`lst_create_node`](diffhunk://#diff-75bbd596cf86e71dc71e9eaa2bbaf8c64cd54b128422e54876d8145d12f7891eR19-R24): Creates a new environment list node.
  - [`lst_add_end`](diffhunk://#diff-75bbd596cf86e71dc71e9eaa2bbaf8c64cd54b128422e54876d8145d12f7891eR38-R42): Adds a new node to the end of the environment list.
  - [`lst_init`](diffhunk://#diff-75bbd596cf86e71dc71e9eaa2bbaf8c64cd54b128422e54876d8145d12f7891eR60-R64): Initializes the environment list from an `envp` array.
  - [`lst_clear`](diffhunk://#diff-75bbd596cf86e71dc71e9eaa2bbaf8c64cd54b128422e54876d8145d12f7891eR82-R85): Clears the environment list and frees memory.
  - [`lst_size`](diffhunk://#diff-75bbd596cf86e71dc71e9eaa2bbaf8c64cd54b128422e54876d8145d12f7891eR104-R108): Returns the size of the environment list.

### Metadata Updates:
* Updated author and timestamp metadata in file headers across `src/env/env_list_to_tab.c`, `src/env/env_list_utils.c`, and `src/env/envp_list.c`. [[1]](diffhunk://#diff-f56fee0965d8eee1dc545d113f8c8391952395b68e4d4d92befe323ce3a67da7L9-R9) [[2]](diffhunk://#diff-e56ac795c3a189389f4c28d8a9c54ad2b550e6f45955182f0b2efa6c13fddecfL6-R9) [[3]](diffhunk://#diff-75bbd596cf86e71dc71e9eaa2bbaf8c64cd54b128422e54876d8145d12f7891eL6-R9)