### PR TITLE
Cleanup executor

### DIFF
--- a/src/executor/executor.c
+++ b/src/executor/executor.c
@@ -6,7 +6,7 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/06 12:38:33 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/06/19 18:45:23 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/06/20 11:03:35 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,11 @@
 #include "ft_printf.h"
 #include <signal.h>
 #include <sys/wait.h>
+
+static int	preprocess_heredocs(t_cmd *cmd_list, t_shell *sh);
+static void	finalize_execution(pid_t last_pid, t_shell *sh);
+static void	execute_cmds(t_cmd *cmd, t_shell *sh);
+static void	run_single_command(t_cmd *cmd, t_shell *sh);
 
 /**
  * @brief Preprocess heredocs in the command list.

--- a/src/executor/executor_child.c
+++ b/src/executor/executor_child.c
@@ -6,18 +6,20 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/11 13:27:52 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/06/19 18:05:14 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/06/20 10:59:55 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "builtins.h"
-#include "env.h"
 #include "executor.h"
 #include "ft_printf.h"
-#include "libft.h"
-#include "minishell.h"
 #include <signal.h>
 #include <stdlib.h>
+
+static void	handle_cmd_not_found(t_shell *sh, char *cmd_name, int exit_code);
+static void	execute_external_command(t_cmd *cmd, t_shell *sh);
+static void	execute_child(t_cmd *current_cmd, t_shell *sh);
+static void	setup_child_fds(int prev_fd, t_pipe pd, t_cmd *cmd);
 
 /**
  * @brief Handles the case when a command is not found.

--- a/src/executor/find_command.c
+++ b/src/executor/find_command.c
@@ -6,20 +6,14 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/06 16:19:56 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/06/18 22:41:33 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/06/20 11:06:05 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "env.h"
 #include "ft_printf.h"
-#include "libft.h"
 #include "minishell.h"
 #include "executor.h"
-#include <errno.h>
-#include <stdio.h>
 #include <stdlib.h>
-#include <sys/stat.h>
-#include <unistd.h>
 
 static char	*get_from_env(char **envp, char *key);
 static char	*build_command_path(char *dir, char *cmd);

--- a/src/executor/heredoc.c
+++ b/src/executor/heredoc.c
@@ -6,11 +6,10 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/11 13:27:27 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/06/19 19:33:06 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/06/20 11:10:31 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "env.h"
 #include "executor.h"
 #include "libft.h"
 #include <fcntl.h>
@@ -18,6 +17,11 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <sys/wait.h>
+
+static int	process_heredoc_line(char *line, int fd, t_redir *redir,
+				t_shell *sh);
+static int	write_heredoc_content(t_redir *redir, t_shell *sh);
+static int	wait_for_heredoc(pid_t pid, t_shell *sh);
 
 /**
  * @brief Process a line read from the heredoc input.

--- a/src/executor/redirection.c
+++ b/src/executor/redirection.c
@@ -6,14 +6,18 @@
 /*   By: tsargsya <tsargsya@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/11 13:27:40 by tsargsya          #+#    #+#             */
-/*   Updated: 2025/06/19 19:35:08 by tsargsya         ###   ########.fr       */
+/*   Updated: 2025/06/20 11:13:18 by tsargsya         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "executor.h"
 #include <fcntl.h>
-#include <readline/readline.h>
+#include <stdio.h>
 #include <unistd.h>
+
+static int	open_redirection_file(t_redir *redir);
+static int	redirect_fd_to_stdio(int fd, t_redir *redir);
+static int	apply_one_redir(t_redir *redir);
 
 /**
  * @brief Opens the redirection file based on the type of redirection.


### PR DESCRIPTION
This pull request introduces several changes to the `executor` module, focusing on adding static function declarations for better encapsulation and removing unused includes to clean up the codebase. These changes improve modularity and maintainability.

### Functionality Enhancements:
* Added static function declarations in `src/executor/executor.c` to encapsulate functionality, including `preprocess_heredocs`, `finalize_execution`, `execute_cmds`, and `run_single_command`.
* Added static function declarations in `src/executor/executor_child.c` for handling child process execution, such as `handle_cmd_not_found`, `execute_external_command`, `execute_child`, and `setup_child_fds`.
* Added static function declarations in `src/executor/heredoc.c` for heredoc processing, such as `process_heredoc_line`, `write_heredoc_content`, and `wait_for_heredoc`.
* Added static function declarations in `src/executor/redirection.c` for handling file redirection, including `open_redirection_file`, `redirect_fd_to_stdio`, and `apply_one_redir`.

### Code Cleanup:
* Removed unused includes from multiple files (`src/executor/executor_child.c`, `src/executor/find_command.c`, `src/executor/heredoc.c`) to streamline dependencies and improve readability. [[1]](diffhunk://#diff-449ff6443c0b448a51584097a13c010a5d49a46d3787cd413fa0547100fa0ed3L9-R23) [[2]](diffhunk://#diff-1745415d9b3e89e7d08a26fa1ad96d9b8243f40adca5860f1bac0ca100ae095dL9-L22) [[3]](diffhunk://#diff-919444b332983030d4891a977a4cc56c83a50b1365574aa88f88aeaea70338c9L9-L13)